### PR TITLE
Validate PowerShell packaging targets

### DIFF
--- a/PowerShellToolsPro.Packager.Test/PowerShellToolsPro.Packager.Test.csproj
+++ b/PowerShellToolsPro.Packager.Test/PowerShellToolsPro.Packager.Test.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ModuleCompilerTests.cs" />
     <Compile Include="OldCompiler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ValidateStageTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PowerShellToolsPro.Packager.Test.TestModule\PowerShellToolsPro.Packager.Test.TestModule.csproj">

--- a/PowerShellToolsPro.Packager.Test/ValidateStageTests.cs
+++ b/PowerShellToolsPro.Packager.Test/ValidateStageTests.cs
@@ -1,0 +1,30 @@
+using System;
+using PowerShellToolsPro.Packager;
+using PowerShellToolsPro.Packager.Config;
+using Xunit;
+
+namespace PowerShellToolsPro.Test.Packager
+{
+    public class ValidateStageTests
+    {
+        [Fact]
+        public void ShouldRejectDotNetFrameworkWithPowerShellCore()
+        {
+            var process = new PackageProcess
+            {
+                Config = new PsPackConfig
+                {
+                    Package = new PackageConfig
+                    {
+                        DotNetVersion = "v4.6.2",
+                        PowerShellVersion = "7.4.1"
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<Exception>(() => new ValidateStage().Execute(process, null));
+
+            Assert.Contains(".NET Framework target 'v4.6.2' is not supported with PowerShell '7.4.1'", ex.Message);
+        }
+    }
+}

--- a/PowerShellToolsPro.Packager/PackageProcess.cs
+++ b/PowerShellToolsPro.Packager/PackageProcess.cs
@@ -146,7 +146,7 @@ namespace PowerShellToolsPro.Packager
         {
             if (string.IsNullOrEmpty(process.Config.Package.DotNetVersion)) return;
 
-            var dotNetVersion = process.Config.Package.DotNetVersion.Trim('v').Replace(".", string.Empty);
+            var dotNetVersion = NormalizeDotNetVersion(process.Config.Package.DotNetVersion);
 
             if (!dotNetVersion.StartsWith("net")) dotNetVersion = "net" + dotNetVersion;
 
@@ -181,6 +181,11 @@ namespace PowerShellToolsPro.Packager
             found = false;
             if (process.Config.Package.PowerShellVersion != null)
             {
+                if (IsDotNetFrameworkVersion(dotNetVersion) && process.Config.Package.PowerShellCore)
+                {
+                    throw new Exception($".NET Framework target '{process.Config.Package.DotNetVersion}' is not supported with PowerShell '{process.Config.Package.PowerShellVersion}'. Use Windows PowerShell with .NET Framework or select a .NET Core/.NET 5+ target for PowerShell 7+.");
+                }
+
                 foreach (var version in validNetVersionsForNew)
                 {
                     if (version == dotNetVersion) return;
@@ -191,6 +196,16 @@ namespace PowerShellToolsPro.Packager
                     WriteWarningMessage($"Unvalidated .NET Version specified for selected PowerShell version. Valid values are: {validNetVersionsForNew.Aggregate((x, y) => x + ", " + y)}");
                 }
             }
+        }
+
+        private static string NormalizeDotNetVersion(string dotNetVersion)
+        {
+            return dotNetVersion.Trim('v').Replace(".", string.Empty);
+        }
+
+        private static bool IsDotNetFrameworkVersion(string dotNetVersion)
+        {
+            return dotNetVersion.StartsWith("net4", StringComparison.OrdinalIgnoreCase);
         }
 
         private void ValidatePowerShellVersion(PackageProcess process)
@@ -487,4 +502,3 @@ namespace PowerShellToolsPro.Packager
 
     }
 }
-


### PR DESCRIPTION
PowerShell 7 packaging with a .NET Framework target currently continues into C# compilation and fails with missing PowerShell reference errors. This adds validation so unsupported target combinations fail early with an actionable message.

The validation now rejects .NET Framework targets when PowerShell 7+ is selected, while preserving Windows PowerShell support for .NET Framework packaging. A targeted unit test covers the issue 152 configuration.

Fixes #152