### PR TITLE
Harden VS Code PowerShell connection

### DIFF
--- a/HostInjection/PoshToolsServer.cs
+++ b/HostInjection/PoshToolsServer.cs
@@ -150,7 +150,7 @@ namespace PowerShellToolsPro
                     {
                         WriteLog("Exception in server: " + ex.ToString());
                         Server.Dispose();
-                        Server = new NamedPipeServerStream("PPTPipe", PipeDirection.InOut);
+                        Server = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
                         streamReader = new StreamReader(Server);
                         streamWriter = new StreamWriter(Server);
                     }

--- a/PowerShellToolsPro.Cmdlets/PowerShellToolsPro.Cmdlets.csproj
+++ b/PowerShellToolsPro.Cmdlets/PowerShellToolsPro.Cmdlets.csproj
@@ -66,10 +66,9 @@
   <Target Name="GetCopyToOutputDirectoryItems" />
   <Target Name="SatelliteDllsProjectOutputGroup" />
   <Target Name="DebugSymbolsProjectOutputGroup" />
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(SkipPowerShellProToolsPostBuild)' != 'true'">
     <Exec Command="pwsh -ExecutionPolicy Unrestricted -Command &quot;&amp; $(ProjectDir)post-build.ps1&quot;" />
   </Target>
 
 </Project>
-
 

--- a/vscode/powershellprotools/.vscode/launch.json
+++ b/vscode/powershellprotools/.vscode/launch.json
@@ -17,7 +17,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "Watch with Debug Modules"
         },
         {
             "name": "Extension Tests",
@@ -31,7 +31,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
             ],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "Watch with Debug Modules"
         }
     ]
 }

--- a/vscode/powershellprotools/.vscode/tasks.json
+++ b/vscode/powershellprotools/.vscode/tasks.json
@@ -37,6 +37,28 @@
             ],
             "label": "Build Cmdlets",
             "problemMatcher": []
+        },
+        {
+            "type": "shell",
+            "command": "pwsh",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${workspaceFolder}\\scripts\\Build-DebugModules.ps1"
+            ],
+            "label": "Build Debug Modules",
+            "problemMatcher": []
+        },
+        {
+            "label": "Watch with Debug Modules",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "Build Debug Modules",
+                "npm: watch"
+            ],
+            "problemMatcher": []
         }
     ]
 }

--- a/vscode/powershellprotools/scripts/Build-DebugModules.ps1
+++ b/vscode/powershellprotools/scripts/Build-DebugModules.ps1
@@ -1,0 +1,36 @@
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Debug'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ExtensionRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$RepoRoot = Resolve-Path (Join-Path $ExtensionRoot '..\..')
+$ModulesRoot = Join-Path $ExtensionRoot 'Modules'
+$VSCodeModuleOutput = Join-Path $ModulesRoot 'PowerShellProTools.VSCode'
+$PowerShellProToolsOutput = Join-Path $ModulesRoot 'PowerShellProTools'
+
+Remove-Item $VSCodeModuleOutput -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item $PowerShellProToolsOutput -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $VSCodeModuleOutput -Force | Out-Null
+New-Item -ItemType Directory -Path $PowerShellProToolsOutput -Force | Out-Null
+
+$HostInjectionProject = Join-Path $RepoRoot 'HostInjection\PowerShellProTools.Common.csproj'
+$CmdletsProject = Join-Path $RepoRoot 'PowerShellToolsPro.Cmdlets\PowerShellToolsPro.Cmdlets.csproj'
+
+Push-Location $RepoRoot
+try {
+    dotnet build $HostInjectionProject -c $Configuration -o $VSCodeModuleOutput
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to build PowerShellProTools.VSCode module."
+    }
+
+    dotnet publish $CmdletsProject -f netstandard2.0 -c $Configuration -o $PowerShellProToolsOutput -p:SkipPowerShellProToolsPostBuild=true
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to build PowerShellProTools module."
+    }
+}
+finally {
+    Pop-Location
+}

--- a/vscode/powershellprotools/src/commands/statusBarItemMenu.ts
+++ b/vscode/powershellprotools/src/commands/statusBarItemMenu.ts
@@ -10,7 +10,7 @@ export function statusBarItemMenu() {
         if (Container.PowerShellService.status === SessionStatus.Failed) {
             var retry = await vscode.window.showErrorMessage("PowerShell Pro Tools session failed to start. Please check the PowerShell Pro Tools extension output for more information.", "Retry");
             if (retry === "Retry") {
-                Container.PowerShellService.Reconnect(() => { });
+                Container.PowerShellService.Reconnect(() => { }).catch(error => Container.Log("Retry failed. " + error));
             }
             return;
         }

--- a/vscode/powershellprotools/src/extension.ts
+++ b/vscode/powershellprotools/src/extension.ts
@@ -92,14 +92,32 @@ export async function activate(context: vscode.ExtensionContext) {
         return;
     }
 
-    if (!extension.isActive) {
-        await extension.activate();
-        const powerShellExtensionClient = extension!.exports as IPowerShellExtensionClient;
-        const id = powerShellExtensionClient.registerExternalExtension(context.extension.id);
-        await powerShellExtensionClient.waitUntilStarted(id);
-    }
+    await extension.activate();
+    const powerShellExtensionClient = extension!.exports as IPowerShellExtensionClient;
+    const id = powerShellExtensionClient.registerExternalExtension(context.extension.id);
+    context.subscriptions.push({
+        dispose: () => powerShellExtensionClient.unregisterExternalExtension(id)
+    });
+    await powerShellExtensionClient.waitUntilStarted(id);
 
     await finishActivation(context);
+}
+
+function delay(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForPowerShellExtensionTerminal() {
+    for (let attempt = 0; attempt < 60; attempt++) {
+        const terminal = vscode.window.terminals.find(x => x.name.startsWith("PowerShell Extension"));
+        if (terminal) {
+            return terminal;
+        }
+
+        await delay(1000);
+    }
+
+    return null;
 }
 
 async function finishActivation(context: vscode.ExtensionContext) {
@@ -108,11 +126,7 @@ async function finishActivation(context: vscode.ExtensionContext) {
 
     const treeViewProviders = createTreeViews(context);
 
-    let terminal = null;
-    do {
-        terminal = vscode.window.terminals.find(x => x.name.startsWith("PowerShell Extension"));
-    } while (!terminal)
-
+    const terminal = await waitForPowerShellExtensionTerminal();
     if (terminal == null) {
         throw "PowerShell Extension not found.";
     }
@@ -122,7 +136,7 @@ async function finishActivation(context: vscode.ExtensionContext) {
 
     Container.Log("Connecting to PowerShell Editor Services.");
 
-    powerShellService.Connect(() => {
+    await powerShellService.Connect(() => {
         treeViewProviders.forEach(provider => provider.refresh());
 
         Container.Log("Starting code analysis.");

--- a/vscode/powershellprotools/src/services/performanceService.ts
+++ b/vscode/powershellprotools/src/services/performanceService.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Container } from '../container';
 import { load } from '../settings';
+import { SessionStatus } from './powershellservice';
 
 export class PerformanceService {
     private statusBarItem: vscode.StatusBarItem;
@@ -34,8 +35,17 @@ export class PerformanceService {
         const refreshInterval = settings.statusBar.performanceRefreshInterval * 1000;
 
         const interval = setInterval(async () => {
-            const performance = await Container.PowerShellService.GetPerformance();
-            perfService.statusBarItem.text = `$(dashboard) MEM ${performance.Memory}, CPU ${performance.Cpu}`
+            if (Container.PowerShellService.status !== SessionStatus.Connected) {
+                return;
+            }
+
+            try {
+                const performance = await Container.PowerShellService.GetPerformance();
+                perfService.statusBarItem.text = `$(dashboard) MEM ${performance.Memory}, CPU ${performance.Cpu}`
+            }
+            catch (error) {
+                Container.Log("Failed to update PowerShell performance. " + error);
+            }
         }, refreshInterval);
 
         this.statusBarItem.tooltip = "PowerShell Performance";

--- a/vscode/powershellprotools/src/services/powershellservice.ts
+++ b/vscode/powershellprotools/src/services/powershellservice.ts
@@ -23,6 +23,7 @@ export class PowerShellService {
     private logger: net.Socket;
     private sessionStatus: SessionStatus;
     private reconnectDepth: number = 0;
+    private reconnectPromise: Promise<void>;
 
     get status() {
         return this.sessionStatus;
@@ -51,17 +52,47 @@ export class PowerShellService {
             context.subscriptions.push(this.statusBarItem)
         }
 
-        if (pipeName) {
-            this.pipeName = pipeName;
-        }
-        else {
-            this.pipeName = randomstring.generate({
-                length: 12,
-                charset: 'alphabetic'
-            }).toLowerCase();
-        }
+        this.pipeName = pipeName || this.generatePipeName();
 
         this.setSessionStatus(SessionStatus.Initializing);
+    }
+
+    private generatePipeName(): string {
+        return randomstring.generate({
+            length: 12,
+            charset: 'alphabetic'
+        }).toLowerCase();
+    }
+
+    private resetPipeName(): void {
+        this.pipeName = this.generatePipeName();
+        Container.Log(`Generated new PowerShell Pro Tools pipe name: ${this.pipeName}`);
+    }
+
+    private getPipePath(pipeName: string, suffix: string = ""): string {
+        if (process.platform === "win32") {
+            return `\\\\.\\pipe\\${pipeName}${suffix}`;
+        }
+
+        return path.join(os.tmpdir(), `CoreFxPipe_${pipeName}${suffix}`);
+    }
+
+    private delay(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    private async waitForPowerShellExtensionTerminal(): Promise<vscode.Terminal> {
+        for (let attempt = 0; attempt < 60; attempt++) {
+            const terminal = vscode.window.terminals.find(x => x.name.startsWith("PowerShell Extension"));
+            if (terminal) {
+                return terminal;
+            }
+
+            Container.Log("PowerShell Extension terminal is not available yet.");
+            await this.delay(1000);
+        }
+
+        throw "PowerShell Extension not found.";
     }
 
     setSessionStatus(status: SessionStatus): void {
@@ -94,37 +125,60 @@ export class PowerShellService {
         this.sessionStatus = status;
     }
 
-    Reconnect(callback) {
-        this.reconnectDepth++;
+    Reconnect(callback): Promise<void> {
+        if (this.status === SessionStatus.Disabled) {
+            return Promise.reject("PowerShell Pro Tools is disabled.");
+        }
+
+        if (this.reconnectPromise) {
+            Container.Log("Reconnect already in progress.");
+            return this.reconnectPromise.then(() => callback());
+        }
+
+        this.reconnectPromise = this.reconnect(callback).then(() => {
+            this.reconnectPromise = null;
+        }, (error) => {
+            this.reconnectPromise = null;
+            throw error;
+        });
+
+        return this.reconnectPromise;
+    }
+
+    private async reconnect(callback): Promise<void> {
         this.setSessionStatus(SessionStatus.Initializing);
         this.logger?.destroy();
 
-        if (this.reconnectDepth > 10) {
-            Container.Log("Reconnect depth exceeded. Connection failed.");
-            this.setSessionStatus(SessionStatus.Failed);
-            return;
-        }
-
-        const handle = setInterval(async () => {
-            var terminal = vscode.window.terminals.find(x => x.name.startsWith("PowerShell Extension"));
-            if (terminal == null) {
-                Container.Log("Terminal has not restarted.");
+        for (this.reconnectDepth = 1; this.reconnectDepth <= 10; this.reconnectDepth++) {
+            try {
+                Container.Log(`Reconnect attempt ${this.reconnectDepth}.`);
+                await this.Connect(callback, true);
+                this.reconnectDepth = 0;
                 return;
             }
+            catch (error) {
+                Container.Log(`Reconnect attempt ${this.reconnectDepth} failed. ${error}`);
+                await this.delay(5000);
+            }
+        }
 
-            Container.Log("PowerShell Extension has restarted. Connecting.");
-
-            clearInterval(handle);
-            this.Connect(callback);
-        }, 5000);
+        Container.Log("Reconnect depth exceeded. Connection failed.");
+        this.setSessionStatus(SessionStatus.Failed);
+        throw "Reconnect depth exceeded.";
     }
 
-    Connect(callback) {
+    async Connect(callback, refreshPipeName: boolean = false): Promise<void> {
         if (this.status === SessionStatus.Connected) {
             Container.Log("Already connected to PowerShell process.");
             callback();
             return;
         }
+
+        if (refreshPipeName) {
+            this.resetPipeName();
+        }
+
+        this.setSessionStatus(SessionStatus.Initializing);
 
         var cmdletPath = path.join(vscode.extensions.getExtension("ironmansoftware.powershellprotools").extensionPath, "Modules", "PowerShellProTools.VSCode", "PowerShellProTools.VSCode.psd1");
         if (!fs.existsSync(cmdletPath)) {
@@ -135,34 +189,66 @@ export class PowerShellService {
             poshToolsModulePath = path.join(vscode.extensions.getExtension("ironmansoftware.powershellprotools").extensionPath, "src", "Modules", "PowerShellProTools", "PowerShellProTools.psd1");
         }
 
-        var terminal = vscode.window.terminals.find(x => x.name.startsWith("PowerShell Extension"));
-        if (terminal != null) {
-            Container.Log("Importing module in PowerShell and starting server.");
-            terminal.sendText(`Import-Module '${cmdletPath}'`, true);
-            terminal.sendText(`Import-Module '${poshToolsModulePath}'`, true);
-            terminal.sendText(`Start-PoshToolsServer -PipeName '${this.pipeName}'`, true);
+        const terminal = await this.waitForPowerShellExtensionTerminal();
+        Container.Log("Importing module in PowerShell and starting server.");
+        terminal.sendText(`Import-Module '${cmdletPath}'`, true);
+        terminal.sendText(`Import-Module '${poshToolsModulePath}'`, true);
+        terminal.sendText(`Start-PoshToolsServer -PipeName '${this.pipeName}'`, true);
 
-            const settings = load();
+        const settings = load();
 
-            if (settings.clearScreenAfterLoad) {
-                terminal.sendText('Clear-Host', true);
-            }
-
-        } else {
-            Container.Log("PowerShell Extension not found.");
-            this.setSessionStatus(SessionStatus.Failed);
-            throw ("PowerShell Extension not found.");
+        if (settings.clearScreenAfterLoad) {
+            terminal.sendText('Clear-Host', true);
         }
 
-        setTimeout(() => {
-            Container.Log("Connecting named pipe to PoshTools server.");
-            var pipePath = path.join(os.tmpdir(), `CoreFxPipe_${this.pipeName}_log`);
-            if (process.platform === "win32") {
-                pipePath = `\\\\.\\pipe\\${this.pipeName}_log`;
-            }
+        await this.connectLogger(this.pipeName);
+        await this.invokeMethodWithRetry("Connect", []);
 
-            this.logger = net.connect(pipePath);
-            this.logger.on('data', (data) => {
+        this.reconnectDepth = 0;
+        this.setSessionStatus(SessionStatus.Connected);
+        Container.FinishInitialize();
+        Container.Log("Connected to PowerShell process.")
+        callback();
+    }
+
+    private async connectLogger(pipeName: string): Promise<void> {
+        let lastError = null;
+        for (let attempt = 0; attempt < 60; attempt++) {
+            try {
+                await this.connectLoggerPipe(pipeName);
+                return;
+            }
+            catch (error) {
+                lastError = error;
+                await this.delay(500);
+            }
+        }
+
+        throw lastError || `Timed out connecting to log pipe for ${pipeName}.`;
+    }
+
+    private connectLoggerPipe(pipeName: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            Container.Log("Connecting log pipe to PoshTools server.");
+
+            const pipePath = this.getPipePath(pipeName, "_log");
+            const logger = net.connect(pipePath);
+            let connected = false;
+            const timeout = setTimeout(() => {
+                if (!connected) {
+                    logger.destroy();
+                    reject(`Timed out connecting to log pipe ${pipePath}.`);
+                }
+            }, 30000);
+
+            logger.once("connect", () => {
+                connected = true;
+                clearTimeout(timeout);
+                this.logger = logger;
+                resolve();
+            });
+
+            logger.on('data', (data) => {
                 try {
                     let buff = Buffer.from(data.toString(), 'base64');
                     let text = buff.toString('utf-8');
@@ -173,17 +259,32 @@ export class PowerShellService {
                 }
             });
 
-            this.invokeMethod("Connect", []).then((result) => {
-                this.reconnectDepth = 0;
-                this.setSessionStatus(SessionStatus.Connected);
-                Container.FinishInitialize();
-                Container.Log("Connected to PowerShell process.")
-                callback();
-            }).catch(x => {
-                Container.Log("Failed to connect to PowerShell process." + x);
-                this.setSessionStatus(SessionStatus.Failed);
+            logger.on("error", (e) => {
+                if (!connected) {
+                    clearTimeout(timeout);
+                    logger.destroy();
+                    reject(e);
+                    return;
+                }
+
+                Container.Log(`Log pipe error. ${e}`);
             });
-        }, 1000);
+        });
+    }
+
+    private async invokeMethodWithRetry(method: string, args: Array<any>): Promise<any> {
+        let lastError = null;
+        for (let attempt = 0; attempt < 60; attempt++) {
+            try {
+                return await this.invokeMethod(method, args, false);
+            }
+            catch (error) {
+                lastError = error;
+                await this.delay(500);
+            }
+        }
+
+        throw lastError || `Timed out invoking ${method}.`;
     }
 
     InvokePowerShell(command: string): Promise<any> {
@@ -201,14 +302,28 @@ export class PowerShellService {
         });
     }
 
-    invokeMethod(method: string, args: Array<any>): Promise<any> {
+    invokeMethod(method: string, args: Array<any>, retryOnFailure: boolean = true): Promise<any> {
         return new Promise((resolve, reject) => {
-            var pipePath = path.join(os.tmpdir(), `CoreFxPipe_${this.pipeName}`);
-            if (process.platform === "win32") {
-                pipePath = `\\\\.\\pipe\\${this.pipeName}`;
+            if (this.status === SessionStatus.Failed || this.status === SessionStatus.Disabled) {
+                reject(`PowerShell Pro Tools is not connected. Status: ${this.status}.`);
+                return;
             }
 
-            var client = net.connect(pipePath, function () {
+            var pipePath = this.getPipePath(this.pipeName);
+            var client: net.Socket;
+            var settled = false;
+            const connectTimeout = setTimeout(() => {
+                settled = true;
+                client?.destroy();
+                reject(`Timed out connecting to named pipe ${pipePath} for ${method}.`);
+            }, 30000);
+
+            client = net.connect(pipePath, function () {
+                if (settled) {
+                    return;
+                }
+
+                clearTimeout(connectTimeout);
                 const request = {
                     method,
                     args
@@ -222,22 +337,44 @@ export class PowerShellService {
             });
 
             client.on("error", (e) => {
+                if (settled) {
+                    return;
+                }
+
+                settled = true;
+                clearTimeout(connectTimeout);
                 Container.Log(`Invoke method: ${method} Error sending data on named pipe. ${e}`);
                 client.destroy();
-                setTimeout(async () => {
-                    await this.Reconnect(() => this.invokeMethod(method, args).then(any => resolve(any)));
-                }, 1000);
+                if ((e as any).code === "ETIMEDOUT") {
+                    reject(e);
+                    return;
+                }
+
+                if (!retryOnFailure) {
+                    reject(e);
+                    return;
+                }
+
+                this.Reconnect(() => { }).then(() => {
+                    return this.invokeMethod(method, args, false);
+                }).then(any => resolve(any), error => reject(error));
             });
 
             client.on('data', (data) => {
+                if (settled) {
+                    return;
+                }
+
+                settled = true;
+                clearTimeout(connectTimeout);
                 try {
                     let buff = Buffer.from(data.toString(), 'base64');
                     let text = buff.toString('utf-8');
                     var response = JSON.parse(text);
                     resolve(response);
                 }
-                catch {
-
+                catch (error) {
+                    reject(error);
                 }
 
                 client.destroy();

--- a/vscode/powershellprotools/src/services/vscodeService.ts
+++ b/vscode/powershellprotools/src/services/vscodeService.ts
@@ -135,7 +135,8 @@ export default class VSCodeService {
         switch (msg.type) {
             case "Terminated":
                 Container.Log("PowerShell Extension has exited. Will attempt to reconnect.");
-                Container.PowerShellService.Reconnect(() => { });
+                Container.PowerShellService.Reconnect(() => { }).catch(error => Container.Log("Reconnect failed. " + error));
+                break;
             case "Out-GridView":
                 this.outDataGridView(msg.args, callback);
                 break;


### PR DESCRIPTION
The VS Code extension could lose its PowerShell Pro Tools pipe connection and then fail to recover without restarting the extension host. This hardens the existing integration path instead of replacing it, so reconnects can recover from stale pipe state and startup races.

## Summary

- Wait for the PowerShell extension session even when it is already active before injecting startup commands.
- Rework reconnects to serialize attempts, use fresh pipe names, retry startup pipe connections, and avoid performance polling while disconnected.
- Fix the host-side pipe recreation path to reuse the requested pipe name.
- Add an F5 prelaunch task for `vscode\powershellprotools` that builds/stages the PowerShell modules required by the extension host.

## Validation

- `npm run compile` from `vscode\powershellprotools`
- `dotnet build .\HostInjection\PowerShellProTools.Common.csproj --no-restore`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\Build-DebugModules.ps1` from `vscode\powershellprotools`
- Imported staged `PowerShellProTools.VSCode` and `PowerShellProTools` modules and verified `Start-PoshToolsServer` is available