### PR TITLE
Vendor InvokeBuild for VS Code builds

### DIFF
--- a/.github/workflows/vscode.ci.yml
+++ b/.github/workflows/vscode.ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Build
       shell: pwsh
       run: |
-        Install-Module InvokeBuild -Scope CurrentUser -Force
+        Import-Module .\Build\Modules\InvokeBuild\5.14.23\InvokeBuild.psd1 -Force
         Install-Module PlatyPS -Scope CurrentUser -Force
         Invoke-Build -File .\vscode\vscode.build.ps1
       env:

--- a/.github/workflows/vscode.production.yml
+++ b/.github/workflows/vscode.production.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Build
       shell: pwsh
       run: |
-        Install-Module InvokeBuild -Scope CurrentUser -Force
+        Import-Module .\Build\Modules\InvokeBuild\5.14.23\InvokeBuild.psd1 -Force
         Install-Module PlatyPS -Scope CurrentUser -Force
         Invoke-Build -File .\vscode\vscode.build.ps1
       env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Prefer targeted validation for the component you changed.
   ```
 - Build the VS Code extension as CI does:
   ```powershell
-  Install-Module InvokeBuild -Scope CurrentUser -Force
+  Import-Module .\Build\Modules\InvokeBuild\5.14.23\InvokeBuild.psd1 -Force
   Install-Module PlatyPS -Scope CurrentUser -Force
   Invoke-Build -File .\vscode\vscode.build.ps1
   ```

--- a/Build/Modules/InvokeBuild/5.14.23/Build-Checkpoint.ps1
+++ b/Build/Modules/InvokeBuild/5.14.23/Build-Checkpoint.ps1
@@ -1,0 +1,148 @@
+<#
+Copyright (c) Roman Kuzmin
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+#>
+
+#.ExternalHelp Help.xml
+[CmdletBinding(DefaultParameterSetName='Default')]
+param(
+	[ValidateNotNullOrEmpty()]
+	[Parameter(Position=0)]
+	[string]$Checkpoint
+	,
+	[Parameter(Position=1)]
+	[hashtable]$Build
+	,
+	[switch]$Preserve
+	,
+	[Parameter(ParameterSetName='Resume', Mandatory=1)]
+	[switch]$Resume
+	,
+	[Parameter(ParameterSetName='Auto', Mandatory=1)]
+	[switch]$Auto
+)
+
+$ErrorActionPreference=1
+try {
+	$_ = if ($PSBoundParameters.ContainsKey('Checkpoint')) {
+		$Checkpoint = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($Checkpoint)
+		if ($Checkpoint.EndsWith('.ps1')) {$Checkpoint}
+	}
+	else {
+		if (($_ = [System.IO.Directory]::GetFiles($PWD, '*.build.ps1')).Length -eq 1) {$_}
+		elseif ($_) {@($_ | Sort-Object)[0]}
+		else {throw 'Missing *.build.ps1'}
+	}
+
+	if ($_) {
+		if ($Build -or $Auto -or $Resume -or $Preserve) {throw 'Omitted or script Checkpoint excludes Build, Auto, Resume, Preserve.'}
+		$Checkpoint = "$_.clixml"
+		$Resume = [System.IO.File]::Exists($Checkpoint)
+		if (!$Resume) {$Build = @{Task = '*'; File = $_}}
+	}
+
+	$Build = if ($Build) {@{} + $Build} else {@{}}
+	if ($Build['WhatIf']) {throw 'WhatIf is not supported.'}
+
+	${*checkpoint} = @{
+		Checkpoint = $Checkpoint
+		Preserve = $Preserve
+		Result = $Build['Result']
+		Data = $null
+	}
+	$Build.Remove('Result')
+
+	if ($Auto) {
+		$Resume = [System.IO.File]::Exists($Checkpoint)
+	}
+
+	if ($Resume) {
+		if (![System.IO.File]::Exists($Checkpoint)) {throw "Missing checkpoint '$Checkpoint'."}
+		${*checkpoint}.Data = try {Import-Clixml $Checkpoint} catch {throw 'Invalid checkpoint file?'}
+
+		foreach($_ in @($Build.get_Keys())) {
+			if ($_ -ne 'Safe' -and $_ -ne 'Summary') {
+				$Build.Remove($_)
+			}
+		}
+		$Build.Task = ${*checkpoint}.Data.Task
+		$Build.File = ${*checkpoint}.Data.File
+		$Build = $Build + ${*checkpoint}.Data.Prm1
+	}
+
+	${*checkpoint}.XBuild = {
+		if (${*checkpoint}.Data) {
+			foreach($_ in ${*checkpoint}.Data.Done) {
+				${*}.All[$_].Elapsed = [TimeSpan]::Zero
+			}
+			foreach($_ in ${*checkpoint}.Data.Prm2.GetEnumerator()) {
+				Set-Variable $_.Key $_.Value -Scope Script
+			}
+			if ($_ = ${*}.Data['Checkpoint.Import']) {
+				. *Run $_ ${*checkpoint}.Data.User
+			}
+		}
+	}
+
+	${*checkpoint}.XCheck = {
+		Export-Clixml ${*checkpoint}.Checkpoint -InputObject @{
+			User = *Run ${*}.Data['Checkpoint.Export']
+			Task = $BuildTask
+			File = $BuildFile
+			Prm1 = $(
+				$r = @{}
+				foreach($_ in ${*}.DP.get_Values()) {
+					if ($_.IsSet) {
+						$r[$_.Name] = $_.Value
+					}
+				}
+				$r
+			)
+			Prm2 = $(
+				$r = @{}
+				foreach($_ in ${*}.DP.get_Keys()) {
+					$r[$_] = Get-Variable -Name $_ -Scope Script -ValueOnly
+				}
+				$r
+			)
+			Done = @(
+				foreach($t in ${*}.All.get_Values()) {
+					if ($t.Elapsed -and !$t.Error) {
+						$t.Name
+					}
+				}
+			)
+		}
+	}
+
+	$_ = $Build
+	Remove-Variable Checkpoint, Build, Preserve, Resume, Auto
+
+	& (Join-Path $PSScriptRoot Invoke-Build.ps1) @_ -Result ${*checkpoint}
+
+	if (!${*checkpoint}.Value.Error -and !${*checkpoint}.Preserve) {
+		[System.IO.File]::Delete(${*checkpoint}.Checkpoint)
+	}
+}
+catch {
+	if ($_.InvocationInfo.ScriptName -notmatch '\b(Invoke-Build|Build-Checkpoint)\.ps1$') {throw}
+	$PSCmdlet.ThrowTerminatingError($_)
+}
+finally {
+	if ($r = ${*checkpoint}.Result) {
+		if ($r -is [string]) {
+			New-Variable $r ${*checkpoint}.Value -Scope 1 -Force
+		}
+		else {
+			$r.Value = ${*checkpoint}.Value
+		}
+	}
+}

--- a/Build/Modules/InvokeBuild/5.14.23/Build-Parallel.ps1
+++ b/Build/Modules/InvokeBuild/5.14.23/Build-Parallel.ps1
@@ -1,0 +1,270 @@
+<#
+Copyright (c) Roman Kuzmin
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+#>
+
+#.ExternalHelp Help.xml
+param(
+	[Parameter(Position=0)]
+	[hashtable[]]$Build
+	,
+	[object]$Result
+	,
+	[int]$Timeout=[int]::MaxValue
+	,
+	[int]$MaximumBuilds=[Environment]::ProcessorCount
+	,
+	[switch]$FailHard
+	,
+	[string[]]$ShowParameter
+)
+
+$ErrorActionPreference=1
+
+# info, result
+$info = [PSCustomObject]@{
+	Tasks = [System.Collections.Generic.List[object]]@()
+	Errors = [System.Collections.Generic.List[object]]@()
+	Warnings = [System.Collections.Generic.List[object]]@()
+	Started = [DateTime]::Now
+	Elapsed = $null
+}
+if ($Result) {
+	if ($Result -is [string]) {
+		New-Variable $Result $info -Scope 1 -Force
+	}
+	else {
+		$Result.Value = $info
+	}
+}
+
+# no builds
+if (!$Build) {return}
+
+# get and source the engine
+$ib = Join-Path $PSScriptRoot Invoke-Build.ps1
+try {. $ib} catch {$PSCmdlet.ThrowTerminatingError($_)}
+
+### make works, check scripts
+$works = @()
+for ($1 = 0; $1 -lt $Build.Count) {
+	$b = @{} + $Build[$1]
+	$Build[$1++] = $b
+
+	if ($file = $b['File']) {
+		if (![System.IO.File]::Exists(($file = *Path $file))) {*Die "Missing script '$file'." 13}
+	}
+	elseif (!($file = Get-BuildFile (*Path))) {
+		*Die "Missing default script in build $1." 5
+	}
+
+	$b.Result = @{}
+	$b.File = $file
+	$b.Safe = $true
+
+	$work = @{}
+	$works += $work
+	$work.Build = $b
+	$work.Done = $false
+	$work.Error1 = $null
+	$work.Error2 = $null
+	$work.Title = "($1/$($Build.Count)) $file"
+	if ($ShowParameter) {
+		foreach($p in $ShowParameter) {
+			$work.Title += " $($p)='$($b[$p])'"
+		}
+	}
+}
+
+### prepare logs and make shells
+foreach($work in $works) {
+	$b = $work.Build
+	if ($log = $b['Log']) {
+		$work.Temp = $false
+		$b.Remove('Log')
+		[System.IO.File]::Delete(($log = *Path $log))
+	}
+	else {
+		$work.Temp = $true
+		$log = [System.IO.Path]::GetTempFileName()
+	}
+	$work.Log = $log
+	$work.PS = [PowerShell]::Create().AddCommand($ib).AddParameters($b).AddCommand('Out-File').AddParameter('FilePath', $log).AddParameter('Encoding', 'UTF8')
+}
+
+function Write-Log($work) {
+	$file = $work.Log
+	if ($work.Temp) {
+		try {
+			$read = [System.IO.File]::OpenText($file)
+			while($null -ne ($_ = $read.ReadLine())) {$_}
+			$read.Close()
+		}
+		catch {
+			Write-Warning $_
+		}
+		[System.IO.File]::Delete($file)
+	}
+	else {
+		"Log: $file"
+	}
+}
+
+### main
+if ($MaximumBuilds -lt 1) {*Die "MaximumBuilds should be a positive number." 5}
+$MaximumBuilds = [math]::Min($MaximumBuilds, $Build.Count)
+$stage = [System.Collections.Generic.List[object]]@()
+$iWork = 0
+$abort = ''
+$failures = @()
+$stopwatch = [Diagnostics.Stopwatch]::StartNew()
+try {
+	for() {
+		### stage next work(s), BeginInvoke
+		while($stage.Count -lt $MaximumBuilds -and $iWork -lt $works.Count) {
+			$work = $works[$iWork++]
+			$stage.Add($work)
+
+			print Cyan "Start $($work.Title)"
+			$work.Job = $work.PS.BeginInvoke()
+		}
+		if (!$stage) {break}
+
+		### wait for any staged
+		$waits = New-Object System.Collections.Generic.List[System.Threading.WaitHandle]
+		foreach($work in $stage) {$waits.Add($work.Job.AsyncWaitHandle)}
+		$time = $Timeout - $stopwatch.ElapsedMilliseconds
+		$index = [System.Threading.WaitHandle]::WaitAny($waits.ToArray(), $time, $true)
+		if ($index -eq [System.Threading.WaitHandle]::WaitTimeout) {
+			$abort = 'Build timed out.'
+			break
+		}
+
+		### unstage done, EndInvoke
+		$work = $stage[$index]
+		$stage.RemoveAt($index)
+		$work.Done = $true
+		try {
+			$work.PS.EndInvoke($work.Job)
+			$work.Error2 = $work.Build.Result.Value.Error
+		}
+		catch {
+			$work.Error1 = "Invalid build arguments or script. Error: $_"
+		}
+
+		### abort?
+		if (($work.Error1 -or $work.Error2) -and $FailHard) {
+			$abort = "Aborted by $($work.Title)"
+			break
+		}
+	}
+
+	### finish works
+	foreach($work in $works) {
+		print Cyan "Build $($work.Title):"
+
+		### get error and dispose
+		$runtime = $false
+		$_ = try {
+			if ($work.Done) {
+				if ($work.Error1) {
+					$work.Error1
+				}
+				else {
+					$runtime = $true
+					$r = $work.Build.Result.Value
+					$info.Tasks.AddRange($r.Tasks)
+					$info.Errors.AddRange($r.Errors)
+					$info.Warnings.AddRange($r.Warnings)
+					$r.Error
+				}
+			}
+			else {
+				$work.PS.Stop()
+				$abort
+			}
+
+			### streams
+			$streams = $work.PS.Streams
+
+			if ($work.Build['Verbose']) {
+				foreach($_ in $streams.Verbose) {
+					Write-Verbose $_ -Verbose
+				}
+			}
+
+			if ($var = $work.Build['InformationVariable']) {
+				New-Variable $var ([System.Collections.Generic.List[object]]$streams.Information) -Scope 1 -Force
+			}
+
+			if ($null -ne $work.Build['InformationAction']) {
+				foreach($_ in $streams.Information) {
+					Write-Information $_ -InformationAction $work.Build.InformationAction
+				}
+			}
+		}
+		catch {
+			$_
+		}
+		finally {
+			$work.PS.Dispose()
+		}
+
+		### log
+		Write-Log $work
+
+		### result
+		if ($_) {
+			print Cyan "Build $($work.Title) FAILED."
+			$_ = if ($_ -is [System.Management.Automation.ErrorRecord] -and $runtime) {*Msg $_ $_} else {"$_"}
+			print Red "ERROR: $_"
+			$failures += @{
+				File = $work.Title
+				Error = $_
+			}
+		}
+		else {
+			print Cyan "Build $($work.Title) succeeded."
+		}
+	}
+
+	### fail?
+	if ($failures) {
+		*Die ($(
+			"Failed builds:"
+			foreach($_ in $failures) {
+				"Build: $($_.File)"
+				"ERROR: $($_.Error)"
+			}
+		) -join [Environment]::NewLine)
+	}
+}
+finally {
+	$errors = $info.Errors.Count
+	$warnings = $info.Warnings.Count
+	$info.Elapsed = [DateTime]::Now - $info.Started
+
+	if (($up = $PSCmdlet.SessionState.PSVariable.Get('*')) -and ($up = if ($up.Description -eq 'IB') {$up.Value})) {
+		$up.Tasks.AddRange($info.Tasks)
+		$up.Errors.AddRange($info.Errors)
+		$up.Warnings.AddRange($info.Warnings)
+	}
+
+	$color, $text = if ($failures) {12, 'Builds FAILED'}
+	elseif ($errors) {14, 'Builds completed with errors'}
+	elseif ($warnings) {14, 'Builds succeeded with warnings'}
+	else {10, 'Builds succeeded'}
+
+	print $color @"
+Tasks: $($info.Tasks.Count) tasks, $errors errors, $warnings warnings
+$text. $($Build.Count) builds, $($failures.Count) failed $($info.Elapsed)
+"@
+}

--- a/Build/Modules/InvokeBuild/5.14.23/Help.xml
+++ b/Build/Modules/InvokeBuild/5.14.23/Help.xml
@@ -1,0 +1,2131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems xmlns="http://msh" schema="maml">
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Invoke-Build.ps1</command:name>
+<maml:description>
+<maml:para>Invokes build script tasks.</maml:para>
+</maml:description>
+</command:details>
+<maml:description>
+<maml:para>The command invokes so called tasks defined in a PowerShell script.
+Let&apos;s call this process build and a script with tasks build script.
+
+A build script defines parameters, variables, and one or more tasks.
+Any code is invoked with the current location set to $BuildRoot,
+the script directory. $ErrorActionPreference is set to &apos;Stop&apos;.
+
+SCRIPT PARAMETERS
+
+Build scripts define parameters as usual using the param() block.
+On calling, specify them for Invoke-Build as if they are its own.
+
+Known issue #4. Specify script switches after Task and File.
+
+These parameters are reserved for Invoke-Build:
+Task, File, Result, Safe, Summary, WhatIf
+
+COMMANDS AND HELP
+
+Commands available for build scripts:
+
+    task      (Add-BuildTask)
+    exec      (Invoke-BuildExec)
+    assert    (Assert-Build)
+    equals    (Assert-BuildEquals)
+    remove    (Remove-BuildItem)
+    print     (Write-Build)
+    property  (Get-BuildProperty)
+    requires  (Test-BuildAsset)
+    use       (Use-BuildAlias)
+
+    Confirm-Build
+    Get-BuildError
+    Get-BuildFile
+    Get-BuildSynopsis
+    Get-BuildVersion
+    Resolve-MSBuild
+    Set-BuildFooter
+    Set-BuildHeader
+    Use-BuildEnv
+    Write-Warning [1]
+
+[1] Write-Warning is redefined internally in order to count warnings in
+a build script and others called. Warnings in modules are not counted.
+
+To get commands help, dot-source Invoke-Build and then call help:
+
+    PS&gt; . Invoke-Build
+    PS&gt; help task -full
+
+SPECIAL ALIASES
+
+    Invoke-Build
+    Build-Parallel
+    Build-Checkpoint
+
+Aliases are for scripts from the package. Use aliases for calling nested
+builds, i.e. omit &quot;.ps1&quot; extensions, to avoid accidentally calling other
+scripts with same names in the path.
+
+PUBLIC VARIABLES
+
+    $OriginalLocation - where the build is invoked
+    $WhatIf - WhatIf mode, Invoke-Build parameter
+    $BuildRoot - build script location, by default
+    $BuildFile - build script path
+    $BuildTask - initial tasks
+    $Task - current task
+    $Job - current job
+
+All variables except $BuildRoot are for reading and should not be changed.
+$BuildRoot may be changed on loading by top level script code, in order to
+alter the default build directory, and should not be changed after loading.
+
+$Task is available for script blocks defined by task parameters If, Inputs,
+Outputs, and Jobs and by blocks Enter|Exit-BuildTask, Enter|Exit-BuildJob,
+Set-BuildHeader, Set-BuildFooter.
+
+    $Task properties for reading:
+
+    - Name - [string], task name
+    - Jobs - [object[]], task jobs
+    - Started - [DateTime], task start time
+
+    And in Exit-BuildTask:
+
+    - Error - task error or null
+    - Elapsed - [TimeSpan], task duration
+
+    Other properties should not be used by scripts.
+
+$Task also exists in the script scope with the only property Name getting
+$BuildFile, the build script path.
+
+BUILD BLOCKS
+
+Scripts may define special build blocks invoked as:
+
+    Enter-Build {} - before the first task
+    Exit-Build {} - after the last task
+
+    Enter-BuildTask {} - before each task
+    Exit-BuildTask {} - after each task
+
+    Enter-BuildJob {} - before each task script job
+    Exit-BuildJob {} - after each task script job
+
+    Set-BuildHeader {param($Path)} - to write task headers
+    Set-BuildFooter {param($Path)} - to write task footers
+
+Blocks are not called on WhatIf.
+Nested builds do not inherit Enter/Exit blocks.
+Nested builds inherit Set-BuildHeader and Set-BuildFooter.
+If Enter-X is called then Exit-X is also called, even on failures.
+
+Enter-Build and Exit-Build are invoked in the script scope. Enter-Build is
+suitable for initialization and it may output text unlike top level code.
+
+Enter-BuildTask, Exit-BuildTask, Enter-BuildJob, and Exit-BuildJob are
+invoked in the same scope, the parent of task script blocks.
+
+PRIVATE STUFF
+
+Function and variable names starting with &apos;*&apos; are reserved for the engine.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Invoke-Build.ps1</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Task</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>File</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Result</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Safe</maml:name>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Summary</maml:name>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>WhatIf</maml:name>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Task</maml:name>
+<maml:description>
+<maml:para>One or more tasks to invoke. If it is omitted, empty, or equal to &apos;.&apos;
+then the task &apos;.&apos; is invoked if it exists, otherwise the first added
+task is invoked.
+
+Names with wildcard characters are reserved for special cases.
+
+SAFE REFERENCES
+
+If a task &apos;X&apos; is referenced as &apos;?X&apos; then it is allowed to fail without
+breaking the build, i.e. other tasks specified after X will be invoked.
+
+SPECIAL TASKS
+
+? - Tells to show tasks synopses, jobs, and check for issues.
+Task synopses are defined in preceding comments as
+
+    # Synopsis: ...
+
+or
+
+    &lt;#
+    .Synopsis
+    ...
+    #&gt;
+
+?? - Tells to collect and get all tasks as an ordered dictionary.
+It can be used by external tools for analysis, completion, etc.
+
+Tasks ? and ?? set $WhatIf to true. Properly designed build scripts
+should not perform anything significant if $WhatIf is set to true.
+
+* - Tells to invoke all tasks, e.g. tests, step sequences, etc.
+The dot-task and tasks added by other scripts are not included.
+
+** - Invokes * for all files *.test.ps1 found recursively in the
+current directory or a directory specified by the parameter File.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>File</maml:name>
+<maml:description>
+<maml:para>The build script adding tasks by &apos;task&apos; (Add-BuildTask).
+
+If File is omitted then Invoke-Build searches for the first like
+*.build.ps1 in the current location in Sort-Object order.
+
+If this file is not found then `$env:InvokeBuildGetFile` is called with
+a directory path argument in order to get its custom build script path.
+
+If the file is still not found then parent directories are searched.
+
+DIRECTORY PATH
+
+File accepts directory paths as well. The build script is resolved as
+described above for the specified directory without searching parents.
+
+INLINE SCRIPT
+
+File also accepts a script block composed as build script. In this
+case $BuildFile is a file defining the script block. $BuildRoot is
+its directory or $OriginalLocation when $BuildFile is null on
+[scriptblock]::Create() used instead of usual {...}.
+
+Script parameters, parallel, and persistent builds are not supported.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Result</maml:name>
+<maml:description>
+<maml:para>Tells to make the build result. Normally it is the name of a variable
+created in the calling scope. Or it is a hashtable which entry Value
+contains the result.
+
+Result properties:
+
+    All - all available tasks
+    Error - a terminating build error
+    Tasks - invoked tasks including nested
+    Errors - error objects including nested
+    Warnings - warning objects including nested
+    Redefined - list of original redefined tasks
+
+Tasks is a list of objects:
+
+    Name - task name
+    Jobs - task jobs
+    Error - task error
+    Started - start time
+    Elapsed - task duration
+    InvocationInfo - task location (.ScriptName, .ScriptLineNumber)
+
+Errors is a list of objects:
+
+    Error - original error
+    File - current $BuildFile
+    Task - current $Task or null for other errors
+
+Warnings is a list of objects:
+
+    Message - warning message
+    File - script emitting the warning
+    Task - current $Task or null for other warnings
+
+Do not change these data and do not use not documented members.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Safe</maml:name>
+<maml:description>
+<maml:para>Tells to catch a build failure, store an error as the property Error of
+Result and return quietly. A caller should use Result and check Error.
+
+Exceptions are still thrown if the build cannot start, for example:
+build script is missing, invalid, has no tasks.
+
+When Safe is used together with the special task ** (invoke *.test.ps1)
+then task failures stop current test scripts, not the whole testing.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Summary</maml:name>
+<maml:description>
+<maml:para>Tells to show summary information after the build. It includes task
+durations, names, locations, and error messages.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>WhatIf</maml:name>
+<maml:description>
+<maml:para>Tells to show tasks and jobs to be invoked and some analysis of used
+parameters and environment variables. See Show-TaskHelp.ps1 for more.
+
+If a script does anything but adding tasks then it should check for
+$WhatIf and skip actions on true. Consider using Enter-Build instead.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>Text</maml:name>
+</dev:type>
+<maml:description>
+<maml:para>Build log which includes task records and engine messages, warnings,
+errors, and output from build script tasks and special blocks.
+
+The script top level code should not output anything. Unexpected script
+outputs now emit warnings but in the future they may change to errors.</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code>## How to call Invoke-Build in order to deal with build failures.
+## Use one of the below techniques or you may miss some failures.
+
+## (1/2) If you do not want to catch errors and just want the calling
+## script to stop on build failures then
+
+$ErrorActionPreference = &apos;Stop&apos;
+Invoke-Build ...
+
+## (2/2) If you want to catch build errors and proceed further depending
+## on them then use try/catch, $ErrorActionPreference does not matter:
+
+try {
+    Invoke-Build ...
+    # Build completed
+}
+catch {
+    # Build FAILED, $_ is the error
+}</dev:code>
+</command:example>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+<dev:code># Invoke tasks Build and Test from the default script with parameters.
+# The script defines parameters Output and WarningLevel by param().
+
+Invoke-Build Build, Test -Output log.txt -WarningLevel 4</dev:code>
+</command:example>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+<dev:code># Show tasks in the default script and the specified script
+
+Invoke-Build ?
+Invoke-Build ? Project.build.ps1
+
+# Custom formatting is possible, too
+
+Invoke-Build ? | Format-Table -AutoSize
+Invoke-Build ? | Format-List Name, Synopsis</dev:code>
+</command:example>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
+<dev:code># Get task names without invoking for listing, TabExpansion, etc.
+
+$all = Invoke-Build ??
+$all.Keys</dev:code>
+</command:example>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 5 --------------------------</maml:title>
+<dev:code># Invoke all in Test1.test.ps1 and all in Tests\...\*.test.ps1
+
+Invoke-Build * Test1.test.ps1
+Invoke-Build ** Tests</dev:code>
+</command:example>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 6 --------------------------</maml:title>
+<dev:code># How to use build results, e.g. for summary
+
+try {
+    # Invoke build and get the variable Result
+    Invoke-Build -Result Result
+}
+finally {
+    # Show build error
+    &quot;Build error: $(if ($Result.Error) {$Result.Error} else {&apos;None&apos;})&quot;
+
+    # Show task summary
+    $Result.Tasks | Format-Table Elapsed, Name, Error -AutoSize
+}</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:uri>https://github.com/nightroman/Invoke-Build/blob/main/Docs/help/Invoke-Build.ps1.md</maml:uri>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Build-Checkpoint</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Build-Parallel</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>For other commands, at first invoke:</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>PS&gt; . Invoke-Build</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>task      (Add-BuildTask)</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>exec      (Invoke-BuildExec)</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>assert    (Assert-Build)</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>equals    (Assert-BuildEquals)</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>remove    (Remove-BuildItem)</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>print     (Write-Build</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>property  (Get-BuildProperty)</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>requires  (Test-BuildAsset)</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>use       (Use-BuildAlias)</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Confirm-Build</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Get-BuildError</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Get-BuildSynopsis</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Resolve-MSBuild</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Set-BuildFooter</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Set-BuildHeader</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Build-Checkpoint.ps1</command:name>
+<maml:description>
+<maml:para>Invokes persistent builds with checkpoints.</maml:para>
+</maml:description>
+</command:details>
+<maml:description>
+<maml:para>This command invokes the build and saves build state checkpoints after each
+completed task. If the build is interrupted then it may be resumed later
+with the saved checkpoint file.
+
+The built-in Export-Clixml and Import-Clixml are used for saving checkpoints.
+Keep in mind that not all data types are suitable for this serialization.
+
+CUSTOM EXPORT AND IMPORT
+
+By default, the command saves and restores build tasks, script path, and
+all parameters declared by the build script. Tip: consider declaring some
+script variables as artificial parameters in order to make them persistent.
+
+If this is not enough for saving and restoring the build state then use
+custom export and import blocks. The export block is called on writing
+checkpoints, i.e. on each task. The import block is called on resuming
+once, before the task to be resumed.
+
+The export block is set by `Set-BuildData Checkpoint.Export`, e.g.
+
+    Set-BuildData Checkpoint.Export {
+        $script:var1
+        $script:var2
+    }
+
+The import block is set by `Set-BuildData Checkpoint.Import`, e.g.
+
+    Set-BuildData Checkpoint.Import {
+        param($data)
+        $var1, $var2 = $data
+    }
+
+The import block is called in the script scope. Thus, $var1 and $var2 are
+script variables right away. We may but do not have to use the prefix.
+
+The parameter $data is the output of Checkpoint.Export exported to clixml
+and then imported from clixml.
+
+OMITTED OR SCRIPT CHECKPOINT
+
+Omitted or script Checkpoint and no other parameters is the special
+case. The engine builds all tasks of the default or specified script
+with checkpoints.
+
+The checkpoint path is the script path with added &quot;.clixml&quot;. The persistent
+build starts if the checkpoint does not exist, otherwise resumes with the
+existing checkpoint.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Build-Checkpoint.ps1</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Checkpoint</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Build</maml:name>
+<command:parameterValue required="true">Hashtable</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Preserve</maml:name>
+</command:parameter>
+</command:syntaxItem>
+<command:syntaxItem>
+<maml:name>Build-Checkpoint.ps1</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Checkpoint</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Build</maml:name>
+<command:parameterValue required="true">Hashtable</command:parameterValue>
+</command:parameter>
+<command:parameter required="true" position="named" >
+<maml:name>Auto</maml:name>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Preserve</maml:name>
+</command:parameter>
+</command:syntaxItem>
+<command:syntaxItem>
+<maml:name>Build-Checkpoint.ps1</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Checkpoint</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Build</maml:name>
+<command:parameterValue required="true">Hashtable</command:parameterValue>
+</command:parameter>
+<command:parameter required="true" position="named" >
+<maml:name>Resume</maml:name>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Preserve</maml:name>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Checkpoint</maml:name>
+<maml:description>
+<maml:para>Specifies the checkpoint file (clixml). The checkpoint file is removed
+after successful builds unless the switch Preserve is specified.
+
+See DESCRIPTION / OMITTED OR SCRIPT CHECKPOINT for the special case.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Build</maml:name>
+<maml:description>
+<maml:para>Specifies the build and script parameters. WhatIf is not supported.
+
+When the build resumes by Resume or Auto then fields Task, File, and
+script parameters are ignored and restored from the checkpoint file.
+But fields Result, Safe, Summary are used as usual build parameters.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="true" position="named" >
+<maml:name>Auto</maml:name>
+<maml:description>
+<maml:para>Tells to start a new build if the checkpoint file is not found or
+resume the build from the found checkpoint file.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Preserve</maml:name>
+<maml:description>
+<maml:para>Tells to preserve the checkpoint file on successful builds.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="true" position="named" >
+<maml:name>Resume</maml:name>
+<maml:description>
+<maml:para>Tells to resume the build from the existing checkpoint file.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>Text</maml:name>
+</dev:type>
+<maml:description>
+<maml:para>Output of the invoked build.</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Invoke a persistent sequence of steps defined as tasks.
+Build-Checkpoint temp.clixml @{Task = &apos;*&apos;; File = &apos;Steps.build.ps1&apos;}
+
+# Given the above failed, resume at the failed step.
+Build-Checkpoint temp.clixml -Resume</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Invoke-Build</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Build-Parallel.ps1</command:name>
+<maml:description>
+<maml:para>Invokes parallel builds by Invoke-Build.</maml:para>
+</maml:description>
+</command:details>
+<maml:description>
+<maml:para>This script invokes several build scripts simultaneously by Invoke-Build.
+Number of parallel builds is set to the number of processors by default.
+
+NOTE: Avoid using Build-Parallel in scenarios with PowerShell classes.
+Known issues: https://github.com/nightroman/Invoke-Build/issues/180
+
+VERBOSE STREAM
+
+Verbose messages are propagated to the caller if Verbose is set to true in
+build parameters. They are written all together before the build output.
+
+    Build-Parallel @(
+        @{File=...; Task=...; Verbose=$true}
+        ...
+    )
+
+INFORMATION STREAM
+
+Information messages are propagated to the caller if InformationAction is
+set to Continue in build parameters. They are written all together before
+the build output.
+
+    Build-Parallel @(
+        @{File=...; Task=...; InformationAction=&apos;Continue&apos;}
+        ...
+    )
+
+In addition or instead, information messages are collected in the variable
+specified by InformationVariable in build parameters.
+
+    Build-Parallel @(
+        @{File=...; Task=...; InformationVariable=&apos;info&apos;}
+        ...
+    )
+
+    # information messages
+    $info</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Build-Parallel.ps1</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Build</maml:name>
+<command:parameterValue required="true">Hashtable[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>MaximumBuilds</maml:name>
+<command:parameterValue required="true">Int32</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Result</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>ShowParameter</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Timeout</maml:name>
+<command:parameterValue required="true">Int32</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>FailHard</maml:name>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Build</maml:name>
+<maml:description>
+<maml:para>Build parameters defined as hashtables with these keys/data:
+
+    Task, File, ... - Invoke-Build.ps1 and script parameters
+    Log - Tells to write build output to the specified file
+
+Any number of builds is allowed, including 0 and 1. The maximum number
+of parallel builds is the number of processors by default. It can be
+changed by the parameter MaximumBuilds.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>FailHard</maml:name>
+<maml:description>
+<maml:para>Tells to abort all builds if any build fails.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>MaximumBuilds</maml:name>
+<maml:description>
+<maml:para>Maximum number of builds invoked at the same time.</maml:para>
+</maml:description>
+<dev:defaultValue>Number of processors.</dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Result</maml:name>
+<maml:description>
+<maml:para>Tells to output build results using a variable. It is either a name of
+variable to be created for results or any object with the property
+Value to be assigned ([ref], [hashtable]).
+
+Result properties:
+
+    Tasks - tasks (*)
+    Errors - errors (*)
+    Warnings - warnings (*)
+    Started - start time
+    Elapsed - build duration
+
+(*) see: help Invoke-Build -Parameter Result</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>ShowParameter</maml:name>
+<maml:description>
+<maml:para>Tells to show the specified parameter values in build titles.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Timeout</maml:name>
+<maml:description>
+<maml:para>Maximum overall build time in milliseconds.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>Text</maml:name>
+</dev:type>
+<maml:description>
+<maml:para>Output of invoked builds and other log messages.</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code>Build-Parallel @(
+    @{File=&apos;Project1.build.ps1&apos;}
+    @{File=&apos;Project2.build.ps1&apos;; Task=&apos;MakeHelp&apos;}
+    @{File=&apos;Project2.build.ps1&apos;; Task=&apos;Build&apos;, &apos;Test&apos;}
+    @{File=&apos;Project3.build.ps1&apos;; Log=&apos;C:\TEMP\Project3.log&apos;}
+    @{File=&apos;Project4.build.ps1&apos;; Configuration=&apos;Release&apos;}
+)</dev:code>
+<dev:remarks>
+<maml:para>Five parallel builds are invoked with various combinations of parameters.
+Note that it is fine to invoke the same build script more than once if
+build flows specified by different tasks do not conflict.</maml:para>
+</dev:remarks>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Invoke-Build</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Add-BuildTask</command:name>
+<maml:description>
+<maml:para>(task) Defines and adds a task.</maml:para>
+</maml:description>
+<command:verb>Add</command:verb>
+<command:noun>BuildTask</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Scripts use its alias &apos;task&apos;. It is normally used in the build script scope
+but it can be called from another script or function. Build scripts should
+have at least one task.
+
+This command is all that build scripts really need. Tasks are main build
+blocks. Other build commands are helpers, scripts do not have to use them.
+
+In addition to task parameters, you may use task help comments, synopses,
+preceding task definitions:
+
+    # Synopsis: ...
+    task ...
+
+Synopses are used in task help information returned by the command
+
+    Invoke-Build ?
+
+To get a task synopsis during a build, use Get-BuildSynopsis.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Add-BuildTask</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Name</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Jobs</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>After</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Before</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Data</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Done</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>If</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Inputs</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Outputs</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Source</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Partial</maml:name>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Name</maml:name>
+<maml:description>
+<maml:para>The task name. Wildcard characters are deprecated and &quot;?&quot; must not be
+the first character. Duplicated names are allowed, each added task
+overrides previously added with the same name.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Jobs</maml:name>
+<maml:description>
+<maml:para>Specifies one or more task jobs or a hashtable with actual parameters.
+Jobs are other task references and own actions, script blocks. Any
+number of jobs is allowed. Jobs are invoked in the specified order.
+
+Valid jobs are:
+
+    [string] - an existing task name, normal reference
+    [string] &quot;?Name&quot; - safe reference to a task allowed to fail
+    [scriptblock] - action, a script block invoked for this task
+
+Special value:
+
+    [hashtable] which contains the actual task parameters in addition
+    to the task name. This task definition is more convenient with
+    complex parameters, often typical for incremental tasks.
+
+    Example:
+        task Name @{
+            Inputs = {...}
+            Outputs = {...}
+            Partial = $true
+            Jobs = {
+                process {...}
+            }
+        }</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>After</maml:name>
+<maml:description>
+<maml:para>Tells to add this task to the end of jobs of the specified tasks.
+
+Altered tasks are defined as normal references (TaskName) or safe
+references (?TaskName). In the latter case this inserted task may
+fail without stopping a build.
+
+Parameters After and Before are used in order to alter task jobs
+in special cases when direct changes in task source code are not
+suitable. Use Jobs in order to define relations in usual cases.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Before</maml:name>
+<maml:description>
+<maml:para>Tells to insert this task to jobs of the specified tasks.
+It is inserted before the first action or added to the end.
+
+See After for details.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Data</maml:name>
+<maml:description>
+<maml:para>Any object attached to the task. It is not used by the engine.
+When the task is invoked this object is available as $Task.Data.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Done</maml:name>
+<maml:description>
+<maml:para>Specifies the command or a script block which is invoked after the
+task. Custom handlers should check for $Task.Error if it matters.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>If</maml:name>
+<maml:description>
+<maml:para>Specifies the optional condition to be evaluated. If the condition
+evaluates to false then the task is not invoked. The condition is
+defined in one of two ways depending on the requirements.
+
+Using standard Boolean notation (parenthesis) the condition is checked
+once when the task is defined. A use case for this notation might be
+evaluating a script parameter or another sort of global condition.
+
+    Example:
+        task Task1 -If ($Param1 -eq ...) {...}
+        task Task2 -If ($PSVersionTable.PSVersion.Major -ge 5) {...}
+
+Using script block notation (curly braces) the condition is evaluated
+on task invocation. If a task is referenced by several tasks then the
+condition is evaluated each time until it gets true and the task is
+invoked. The script block notation is normally used for a condition
+that may be defined or changed during the build or just expensive.
+
+    Example:
+        task SomeTask -If {...} {...}</maml:para>
+</maml:description>
+<dev:defaultValue>$true</dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Inputs</maml:name>
+<maml:description>
+<maml:para>Specifies the input items, tells to process the task as incremental,
+and requires the parameter Outputs with the optional switch Partial.
+
+Inputs are file items or paths or a script block which gets them.
+
+Outputs are file paths or a script block which gets them.
+A script block is invoked with input paths piped to it.
+
+Automatic variables for incremental task actions:
+
+    $Inputs - full input paths, array of strings
+    $Outputs - result of the evaluated Outputs
+
+With the switch Partial the task is processed as partial incremental.
+There must be one-to-one correspondence between Inputs and Outputs.
+
+Partial task actions often contain &quot;process {}&quot; blocks.
+Two more automatic variables are available for them:
+
+    $_ - full path of an input item
+    $2 - corresponding output path
+
+See also docs about incremental tasks:
+https://github.com/nightroman/Invoke-Build/blob/main/Docs/README.md</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Outputs</maml:name>
+<maml:description>
+<maml:para>Specifies the output paths of the incremental task, either directly on
+task creation or as a script block invoked with the task. It is used
+together with Inputs. See Inputs for details.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Partial</maml:name>
+<maml:description>
+<maml:para>Tells to process the incremental task as partial incremental.
+It is used with Inputs and Outputs. See Inputs for details.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Source</maml:name>
+<maml:description>
+<maml:para>Specifies the task source. It is used by wrapper functions in order to
+provide the actual source for location messages and synopsis comments.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Dummy task with no jobs
+task Task1
+
+# Alias of another task
+task Task2 Task1
+
+# Combination of tasks
+task Task3 Task1, Task2
+
+# Simple action task
+task Task4 {
+    # action
+}
+
+# Typical complex task: referenced task(s) and one own action
+task Task5 Task1, Task2, {
+    # action after referenced tasks
+}
+
+# Possible complex task: actions and tasks in any required order
+task Task6 {
+    # action before Task1
+},
+Task1, {
+    # action after Task1 and before Task2
+},
+Task2</dev:code>
+<dev:remarks>
+<maml:para>This example shows various possible combinations of task jobs.</maml:para>
+<maml:para></maml:para>
+</dev:remarks>
+</command:example>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+<dev:code># Synopsis: Complex task with parameters as a hashtable.
+task TestAndAnalyse @{
+    If = !$SkipAnalyse
+    Inputs = {
+        Get-ChildItem . -Recurse -Include *.ps1, *.psm1
+    }
+    Outputs = {
+        &apos;Analyser.log&apos;
+    }
+    Jobs = &apos;Test&apos;, {
+        Invoke-ScriptAnalyzer . &gt; Analyser.log
+    }
+}
+
+# Synopsis: Simple task with usual parameters.
+task Test -If (!$SkipTest) {
+    Invoke-Pester
+}</dev:code>
+<dev:remarks>
+<maml:para>Tasks with complex parameters are often difficult to compose in a readable
+way. In such cases use a hashtable in order to specify task parameters in
+addition to the task name. Keys and values correspond to parameter names
+and values.</maml:para>
+</dev:remarks>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Get-BuildError</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Get-BuildSynopsis</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Invoke-BuildExec</command:name>
+<maml:description>
+<maml:para>(exec) Invokes an application and checks $LastExitCode.</maml:para>
+</maml:description>
+<command:verb>Invoke</command:verb>
+<command:noun>BuildExec</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Scripts use its alias &apos;exec&apos;. It invokes the script block which is supposed
+to call an executable. Then $LastExitCode is checked. If it does not match
+the specified codes (0 by default) an error is thrown.
+
+If you have any issues with standard error output of the invoked app, try
+using `exec` with -ErrorAction Continue, SilentlyContinue, or Ignore. This
+does not affect failures of `exec`, they still depend on the app exit code.
+This works around PowerShell standard errors issues.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Invoke-BuildExec</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Command</maml:name>
+<command:parameterValue required="true">ScriptBlock</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>ExitCode</maml:name>
+<command:parameterValue required="true">Int32[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="2" >
+<maml:name>ErrorMessage</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Echo</maml:name>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>StdErr</maml:name>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Command</maml:name>
+<maml:description>
+<maml:para>Command that invokes an executable which exit code is checked. It must
+invoke an application directly (.exe) or not (.cmd, .bat), otherwise
+$LastExitCode is not set and may contain the code of another command.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>ExitCode</maml:name>
+<maml:description>
+<maml:para>Valid exit codes (e.g. 0..3 for robocopy).</maml:para>
+</maml:description>
+<dev:defaultValue>@(0)</dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" position="2" >
+<maml:name>ErrorMessage</maml:name>
+<maml:description>
+<maml:para>Specifies the text included to standard error messages.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Echo</maml:name>
+<maml:description>
+<maml:para>Tells to write the command and its used variable values.
+WARNING: With echo you may expose sensitive information.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>StdErr</maml:name>
+<maml:description>
+<maml:para>Tells to set $ErrorActionPreference to Continue, capture all output and
+write as strings. Then, if the exit code is failure, add the standard
+error output text to the error message.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>Objects</maml:name>
+</dev:type>
+<maml:description>
+<maml:para>Output of the specified command.</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Call robocopy (0..3 are valid exit codes)
+
+exec { robocopy Source Target /mir } (0..3)</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Use-BuildAlias</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Use-BuildEnv</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Assert-Build</command:name>
+<maml:description>
+<maml:para>(assert) Checks for a condition.</maml:para>
+</maml:description>
+<command:verb>Assert</command:verb>
+<command:noun>Build</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Scripts use its alias &apos;assert&apos;. This command checks for a condition and
+if it is not true throws an error with the default or specified message.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Assert-Build</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Condition</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Message</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Condition</maml:name>
+<maml:description>
+<maml:para>The condition.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Message</maml:name>
+<maml:description>
+<maml:para>An optional message describing the assertion condition.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Assert-BuildEquals</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Assert-BuildEquals</command:name>
+<maml:description>
+<maml:para>(equals) Verifies that two specified objects are equal.</maml:para>
+</maml:description>
+<command:verb>Assert</command:verb>
+<command:noun>BuildEquals</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Scripts use its alias &apos;equals&apos;. This command verifies that two specified
+objects are equal using [Object]::Equals(). If objects are not equal the
+command fails with a message showing object values and types.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Assert-BuildEquals</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>A</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>B</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>A</maml:name>
+<maml:description>
+<maml:para>The first object.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>B</maml:name>
+<maml:description>
+<maml:para>The second object.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Assert-Build</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Remove-BuildItem</command:name>
+<maml:description>
+<maml:para>(remove) Removes specified items.</maml:para>
+</maml:description>
+<command:verb>Remove</command:verb>
+<command:noun>BuildItem</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Scripts use its alias &apos;remove&apos;. This command removes existing items,
+ignores missing items, and fails if it cannot remove existing items.
+
+Use the switch Verbose in order to output messages about removing
+existing and skipping missing items or patterns specified by Path.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Remove-BuildItem</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Path</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" globbing="true" >
+<maml:name>Path</maml:name>
+<maml:description>
+<maml:para>Specifies the items to be removed. Wildcards are allowed.
+The parameter is mostly the same as Path of Remove-Item.
+For sanity, paths with only ., *, \, / are not allowed.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Remove some temporary items
+
+remove bin, obj, *.test.log</dev:code>
+</command:example>
+</command:examples>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Write-Build</command:name>
+<maml:description>
+<maml:para>(print) Writes text using colors if they are supported.</maml:para>
+</maml:description>
+<command:verb>Write</command:verb>
+<command:noun>Build</command:noun>
+</command:details>
+<maml:description>
+<maml:para>This function is used in order to output colored text in a console or other
+hosts with colors. Unlike Write-Host it is suitable for redirected output.
+
+Write-Build is designed for tasks and build blocks, not script functions.
+
+With PowerShell 7.2+ and $PSStyle.OutputRendering ANSI, Write-Build uses
+ANSI escape sequences.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Write-Build</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Color</maml:name>
+<command:parameterValue required="true">ConsoleColor</command:parameterValue>
+</command:parameter>
+<command:parameter required="true" position="1" >
+<maml:name>Text</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Color</maml:name>
+<maml:description>
+<maml:para>[System.ConsoleColor] value or its string representation.</maml:para>
+<maml:para>Values : Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="true" position="1" >
+<maml:name>Text</maml:name>
+<maml:description>
+<maml:para>Text written using colors if they are supported.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>String</maml:name>
+</dev:type>
+</command:returnValue>
+</command:returnValues>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Get-BuildProperty</command:name>
+<maml:description>
+<maml:para>(property) Gets the session or environment variable or the default.</maml:para>
+</maml:description>
+<command:verb>Get</command:verb>
+<command:noun>BuildProperty</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Scripts use its alias &apos;property&apos;. The command returns:
+
+    - session variable value if it is not $null or &apos;&apos;
+    - environment variable if it is not $null or &apos;&apos;
+    - default value if it is not $null
+    - error</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Get-BuildProperty</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Name</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Value</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Boolean</maml:name>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Name</maml:name>
+<maml:description>
+<maml:para>Specifies the session or environment variable name.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Value</maml:name>
+<maml:description>
+<maml:para>Specifies the default value. If it is omitted or null then the variable
+must exist with a not empty value. Otherwise an error is thrown.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Boolean</maml:name>
+<maml:description>
+<maml:para>Treats values like 1 and 0 as $true and $false, including strings with
+extra spaces. Others are converted by [System.Convert]::ToBoolean().</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>Object</maml:name>
+</dev:type>
+<maml:description>
+<maml:para>Requested property value.</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Inherit an existing value or throw an error
+
+$OutputPath = property OutputPath</dev:code>
+</command:example>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+<dev:code># Get an existing value or use the default
+
+$WarningLevel = property WarningLevel 4</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Test-BuildAsset</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Test-BuildAsset</command:name>
+<maml:description>
+<maml:para>(requires) Checks for required build assets.</maml:para>
+</maml:description>
+<command:verb>Test</command:verb>
+<command:noun>BuildAsset</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Scripts use its alias &apos;requires&apos;. This command tests the specified assets.
+It fails if any is missing. It is used in script code (common assets) and
+in tasks (individual assets).</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Test-BuildAsset</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Variable</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Environment</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Path</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Property</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Variable</maml:name>
+<maml:description>
+<maml:para>Specifies the required session variable names and tells to fail if a
+variable is missing or its value is null or empty string.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Environment</maml:name>
+<maml:description>
+<maml:para>Specifies the required environment variable names.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Path</maml:name>
+<maml:description>
+<maml:para>Specifies literal paths to be tested by Test-Path. If the specified
+expression uses required assets then test these assets first by a
+separate command.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Property</maml:name>
+<maml:description>
+<maml:para>Specifies session or environment variable names and tells to fail if a
+variable is missing or its value is null or empty string.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Get-BuildProperty</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Use-BuildAlias</command:name>
+<maml:description>
+<maml:para>(use) Sets framework or directory tool aliases.</maml:para>
+</maml:description>
+<command:verb>Use</command:verb>
+<command:noun>BuildAlias</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Scripts use its alias &apos;use&apos;. Invoke-Build does not change the system path
+in order to make framework tools available by names. This is not suitable
+for using mixed framework tools (in different tasks, scripts, parallel
+builds). Instead, this function is used for setting tool aliases in the
+scope where it is called.
+
+This command may be used in the script scope to make aliases for all tasks.
+But it can be called from tasks in order to use more task specific tools.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Use-BuildAlias</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Path</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Name</maml:name>
+<command:parameterValue required="true">String[]</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Path</maml:name>
+<maml:description>
+<maml:para>Specifies the tools directory.
+
+If it is * or it starts with digits followed by a dot then the MSBuild
+path is resolved using the package script Resolve-MSBuild.ps1. Build
+scripts may invoke it directly by the provided alias Resolve-MSBuild.
+The optional suffix x86 tells to use 32-bit MSBuild.
+
+    For just MSBuild use Resolve-MSBuild instead:
+
+        Set-Alias MSBuild (Resolve-MSBuild ...)
+        MSBuild ...
+
+    or
+
+        $MSBuild = Resolve-MSBuild ...
+        &amp; $MSBuild ...
+
+If it is like Framework* then it is assumed to be a path relative to
+Microsoft.NET in the Windows directory.
+
+Otherwise it is a full or relative literal path of any directory.
+
+Examples: *, 4.0, Framework\v4.0.30319, .\Tools</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Name</maml:name>
+<maml:description>
+<maml:para>Specifies the tool names. They become aliases in the current scope.
+If it is a build script then the aliases are created for all tasks.
+If it is a task then the aliases are available just for this task.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Use .NET 4.0 tools MSBuild, csc, ngen. Then call MSBuild.
+
+use 4.0 MSBuild, csc, ngen
+exec { MSBuild Some.csproj /t:Build /p:Configuration=Release }</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Invoke-BuildExec</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Resolve-MSBuild</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Confirm-Build</command:name>
+<maml:description>
+<maml:para>Prompts to confirm an operation.</maml:para>
+</maml:description>
+<command:verb>Confirm</command:verb>
+<command:noun>Build</command:noun>
+</command:details>
+<maml:description>
+<maml:para>This function prints the prompt and options: [Y] Yes [N] No [S] Suspend.
+Choose Y to continue or N to skip. [S] enters the nested prompt, you may
+invoke some commands end then `exit`.
+
+Confirm-Build must not be called during non interactive builds. Scripts
+should take care of this. For example, add the switch $Quiet and define
+Confirm-Build as &quot;Yes to All&quot;:
+
+    if ($Quiet) {function Confirm-Build {$true}}</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Confirm-Build</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Query</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Caption</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Query</maml:name>
+<maml:description>
+<maml:para>The confirmation query. If it is omitted or empty, &quot;Continue with this operation?&quot; is used.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Caption</maml:name>
+<maml:description>
+<maml:para>The confirmation caption. If it is omitted, the current task or script name is used.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>Boolean</maml:name>
+</dev:type>
+</command:returnValue>
+</command:returnValues>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Get-BuildError</command:name>
+<maml:description>
+<maml:para>Gets the specified task error.</maml:para>
+</maml:description>
+<command:verb>Get</command:verb>
+<command:noun>BuildError</command:noun>
+</command:details>
+<maml:description>
+<maml:para>The specified task is usually safe referenced in the build (?name) and a
+caller (usually a downstream task) gets its potential error for analysis.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Get-BuildError</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Task</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Task</maml:name>
+<maml:description>
+<maml:para>Name of the task which error is requested.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>Error</maml:name>
+</dev:type>
+<maml:description>
+<maml:para>An error or null if the task has not failed.</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Add-BuildTask</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Get-BuildFile</command:name>
+<maml:description>
+<maml:para>Gets the found build script path.</maml:para>
+</maml:description>
+<command:verb>Get</command:verb>
+<command:noun>BuildFile</command:noun>
+</command:details>
+<maml:description>
+<maml:para>It gets the build script path for the specified or current location, the
+first like *.build.ps1 in Sort-Object order.
+
+    If this file is not found then `$env:InvokeBuildGetFile` is called with a
+    directory path argument in order to get its custom build script path.
+
+    If the file is still not found then parent directories are searched.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Get-BuildFile</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Path</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Here</maml:name>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Path</maml:name>
+<maml:description>
+<maml:para>Specifies the directory path, defaults to the current location.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="named" >
+<maml:name>Here</maml:name>
+<maml:description>
+<maml:para>Tells not to search in parent directories.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>String</maml:name>
+</dev:type>
+<maml:description>
+<maml:para>The found build script path or null.</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Get-BuildSynopsis</command:name>
+<maml:description>
+<maml:para>Gets the task synopsis.</maml:para>
+</maml:description>
+<command:verb>Get</command:verb>
+<command:noun>BuildSynopsis</command:noun>
+</command:details>
+<maml:description>
+<maml:para>Gets the specified task synopsis if it is available.
+
+Task synopses are defined in preceding comments as
+
+    # Synopsis: ...
+
+or
+
+    &lt;#
+    .Synopsis
+    ...
+    #&gt;
+
+This function may be used in Set-BuildHeader for printing task synopses.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Get-BuildSynopsis</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Task</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Hash</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Task</maml:name>
+<maml:description>
+<maml:para>The task object. During the build, the current task is available as the
+automatic variable $Task.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="false" position="1" >
+<maml:name>Hash</maml:name>
+<maml:description>
+<maml:para>The cache used by external tools. Scripts may omit this parameter.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>String</maml:name>
+</dev:type>
+</command:returnValue>
+</command:returnValues>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Headers: print task paths as usual and synopses in addition
+Set-BuildHeader {
+    param($Path)
+    print Cyan &quot;Task $Path : $(Get-BuildSynopsis $Task)&quot;
+}
+
+# Synopsis: This task prints its own synopsis.
+task Task1 {
+    &apos;My synopsis : &apos; + (Get-BuildSynopsis $Task)
+}</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Set-BuildFooter</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Set-BuildHeader</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Get-BuildVersion</command:name>
+<maml:description>
+<maml:para>Gets version string from file.</maml:para>
+</maml:description>
+<command:verb>Get</command:verb>
+<command:noun>BuildVersion</command:noun>
+</command:details>
+<maml:description>
+<maml:para>It finds the first file line matching Regex and returns its first capturing
+group string.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Get-BuildVersion</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Path</maml:name>
+<command:parameterValue required="true">String</command:parameterValue>
+</command:parameter>
+<command:parameter required="true" position="1" >
+<maml:name>Regex</maml:name>
+<command:parameterValue required="true">Object</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Path</maml:name>
+<maml:description>
+<maml:para>The file with version strings, like change log, release notes, etc.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="true" position="1" >
+<maml:name>Regex</maml:name>
+<maml:description>
+<maml:para>[string] or [regex] defining version as its first capturing group.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>String</maml:name>
+</dev:type>
+</command:returnValue>
+</command:returnValues>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Get version from file
+Get-BuildVersion Release-Notes.md &apos;##\s+v(\d+\.\d+\.\d+)&apos;</dev:code>
+</command:example>
+</command:examples>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Set-BuildFooter</command:name>
+<maml:description>
+<maml:para>Tells how to write task footers.</maml:para>
+</maml:description>
+<command:verb>Set</command:verb>
+<command:noun>BuildFooter</command:noun>
+</command:details>
+<maml:description>
+<maml:para>This build block is used in order to change the default task footer format.
+Use the automatic variable $Task in order to get the current task data.
+Use Write-Build (print) in order to write with colors.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Set-BuildFooter</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Script</maml:name>
+<command:parameterValue required="true">ScriptBlock</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Script</maml:name>
+<maml:description>
+<maml:para>The script like {param($Path) ...} which is used in order to write task
+footers. The parameter Path includes the parent and current task names.
+
+In order to omit task footers, set an empty block:
+
+    Set-BuildFooter {}</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Use the usual footer format but change the color
+Set-BuildFooter {
+    param($Path)
+    print DarkGray &quot;Done $Path $($Task.Elapsed)&quot;
+}
+
+# Synopsis: Data for footers in addition to $Path and $Task.Elapsed
+task Task1 {
+    &apos;Task name     : &apos; + $Task.Name
+    &apos;Start time    : &apos; + $Task.Started
+    &apos;Location path : &apos; + $Task.InvocationInfo.ScriptName
+    &apos;Location line : &apos; + $Task.InvocationInfo.ScriptLineNumber
+}</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Get-BuildSynopsis</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Set-BuildHeader</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Write-Build (print)</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Set-BuildHeader</command:name>
+<maml:description>
+<maml:para>Tells how to write task headers.</maml:para>
+</maml:description>
+<command:verb>Set</command:verb>
+<command:noun>BuildHeader</command:noun>
+</command:details>
+<maml:description>
+<maml:para>This build block is used in order to change the default task header format.
+Use the automatic variable $Task in order to get the current task data.
+Use Write-Build (print) in order to write with colors.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Set-BuildHeader</maml:name>
+<command:parameter required="false" position="0" >
+<maml:name>Script</maml:name>
+<command:parameterValue required="true">ScriptBlock</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="false" position="0" >
+<maml:name>Script</maml:name>
+<maml:description>
+<maml:para>The script like {param($Path) ...} which is used in order to write task
+headers. The parameter Path includes the parent and current task names.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Headers: write task paths as usual and synopses in addition
+Set-BuildHeader {
+    param($Path)
+    print Cyan &quot;Task $Path --- $(Get-BuildSynopsis $Task)&quot;
+}
+
+# Synopsis: Data for headers in addition to $Path and Get-BuildSynopsis
+task Task1 {
+    &apos;Task name     : &apos; + $Task.Name
+    &apos;Start time    : &apos; + $Task.Started
+    &apos;Location path : &apos; + $Task.InvocationInfo.ScriptName
+    &apos;Location line : &apos; + $Task.InvocationInfo.ScriptLineNumber
+}</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Get-BuildSynopsis</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Set-BuildFooter</maml:linkText>
+</maml:navigationLink>
+<maml:navigationLink>
+<maml:linkText>Write-Build (print)</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+<command:details>
+<command:name>Use-BuildEnv</command:name>
+<maml:description>
+<maml:para>Invokes script with temporary changed environment variables.</maml:para>
+</maml:description>
+<command:verb>Use</command:verb>
+<command:noun>BuildEnv</command:noun>
+</command:details>
+<maml:description>
+<maml:para>This command sets the specified environment variables and invokes the
+script. Then it restores the original values of specified variables.</maml:para>
+</maml:description>
+<command:syntax>
+<command:syntaxItem>
+<maml:name>Use-BuildEnv</maml:name>
+<command:parameter required="true" position="0" >
+<maml:name>Env</maml:name>
+<command:parameterValue required="true">Hashtable</command:parameterValue>
+</command:parameter>
+<command:parameter required="true" position="1" >
+<maml:name>Script</maml:name>
+<command:parameterValue required="true">ScriptBlock</command:parameterValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters>
+<command:parameter required="true" position="0" >
+<maml:name>Env</maml:name>
+<maml:description>
+<maml:para>The hashtable of environment variables used by the script.
+Keys and values correspond to variable names and values.</maml:para>
+</maml:description>
+</command:parameter>
+<command:parameter required="true" position="1" >
+<maml:name>Script</maml:name>
+<maml:description>
+<maml:para>The script invoked with the specified variables.</maml:para>
+</maml:description>
+</command:parameter>
+</command:parameters>
+<command:returnValues>
+<command:returnValue>
+<dev:type>
+<maml:name>Objects</maml:name>
+</dev:type>
+<maml:description>
+<maml:para>Output of the specified script.</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+<command:examples>
+<command:example>
+<maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+<dev:code># Invoke with temporary changed Port and Path
+Use-BuildEnv @{
+    Port = &apos;9780&apos;
+    Path = &quot;$PSScriptRoot\Scripts;$env:Path&quot;
+} {
+    exec { dotnet test }
+}</dev:code>
+</command:example>
+</command:examples>
+<maml:relatedLinks>
+<maml:navigationLink>
+<maml:linkText>Invoke-BuildExec</maml:linkText>
+</maml:navigationLink>
+</maml:relatedLinks>
+</command:command>
+</helpItems>

--- a/Build/Modules/InvokeBuild/5.14.23/Invoke-Build.ps1
+++ b/Build/Modules/InvokeBuild/5.14.23/Invoke-Build.ps1
@@ -1,0 +1,915 @@
+<# Invoke-Build 5.14.23
+Copyright (c) Roman Kuzmin
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+#>
+
+#.ExternalHelp Help.xml
+param(
+	[Parameter(Position=0)][string[]]$Task,
+	[Parameter(Position=1)]$File,
+	$Result,
+	[switch]$Safe,
+	[switch]$Summary,
+	[switch]$WhatIf
+)
+
+dynamicparam {
+trap {*Die $_ 5}
+function *Die($M, $C=0) {$PSCmdlet.ThrowTerminatingError((New-Object System.Management.Automation.ErrorRecord ([Exception]"$M"), $null, $C, $null))}
+
+Set-Alias assert Assert-Build
+Set-Alias equals Assert-BuildEquals
+Set-Alias exec Invoke-BuildExec
+Set-Alias print Write-Build
+Set-Alias property Get-BuildProperty
+Set-Alias remove Remove-BuildItem
+Set-Alias requires Test-BuildAsset
+Set-Alias task Add-BuildTask
+Set-Alias use Use-BuildAlias
+Set-Alias Invoke-Build ([System.IO.Path]::Combine($PSScriptRoot, 'Invoke-Build.ps1'))
+Set-Alias Build-Parallel ([System.IO.Path]::Combine($PSScriptRoot, 'Build-Parallel.ps1'))
+Set-Alias Resolve-MSBuild ([System.IO.Path]::Combine($PSScriptRoot, 'Resolve-MSBuild.ps1'))
+
+#.ExternalHelp Help.xml
+function Add-BuildTask(
+	[Parameter(Position=0, Mandatory=1)][string]$Name,
+	[Parameter(Position=1)]$Jobs,
+	[string[]]$After,
+	[string[]]$Before,
+	$If=-9,
+	$Inputs,
+	$Outputs,
+	$Data,
+	$Done,
+	$Source=$MyInvocation,
+	[switch]$Partial
+)
+{
+	trap {*Die "Task '$Name': $_" 5}
+	if (${*}.A -eq 0) {throw 'Cannot add tasks.'}
+	if ($Jobs -is [hashtable]) {
+		if ($PSBoundParameters.get_Count() -ne 2) {throw 'Invalid parameters.'}
+		Add-BuildTask $Name @Jobs -Source:$Source
+		return
+	}
+	if ($Name[0] -eq '?') {throw 'Invalid task name.'}
+	$B1 = ${*}.B1
+	if ($PX = $B1.PX) {
+		filter PX {
+			$r = $_.TrimStart('?')
+			if (!$r.Contains('::') -and $r -ne '.' -and !${*}.All[$r]) {$r = $PX+$r}
+			if ($_[0] -eq '?') {"?$r"} else {$r}
+		}
+		$Name = $Name | PX
+		if ($After) {$After = $After | PX}
+		if ($Before) {$Before = $Before | PX}
+	}
+	if ($_ = ${*}.All[$Name]) {
+		${*}.Redefined += $_
+		${*}.All.Remove($Name)
+	}
+	${*}.All[$Name] = [PSCustomObject]@{
+		Name = $Name
+		Error = $null
+		Started = $null
+		Elapsed = $null
+		Jobs = $1 = [System.Collections.Generic.List[object]]@()
+		After = $After
+		Before = $Before
+		If = $If
+		Inputs = $Inputs
+		Outputs = $Outputs
+		Data = $Data
+		Done = $Done
+		Partial = $Partial
+		InvocationInfo = $Source
+		B1 = $B1
+	}
+	if ($Jobs) {$2 = @(); foreach($j in $Jobs) {
+		$r, $s = *Job $j
+		if ($r -is [string]) {
+			if ($PX) {$r = $r | PX}
+			if ($r -in $2) {${*}.Doubles += ,($Name, $r)} else {$2 += $r}
+			if ($s) {$r = "?$r"}
+		}
+		$1.Add($r)
+	}}
+}
+
+#.ExternalHelp Help.xml
+function Assert-Build([Parameter()]$Condition, [string]$Message) {
+	if (!$Condition) {
+		*Die "Assertion failed.$(if ($Message) {" $Message"})" 7
+	}
+}
+
+#.ExternalHelp Help.xml
+function Assert-BuildEquals([Parameter()]$A, $B) {
+	if (![Object]::Equals($A, $B)) {
+		*Die @"
+Objects are not equal:
+A:$(if ($null -ne $A) {" $A [$($A.GetType())]"})
+B:$(if ($null -ne $B) {" $B [$($B.GetType())]"})
+"@ 7
+	}
+}
+
+#.ExternalHelp Help.xml
+function Confirm-Build([Parameter()][string]$Query, [string]$Caption=$Task.Name) {
+	$PSCmdlet.ShouldContinue($Query, $Caption)
+}
+
+#.ExternalHelp Help.xml
+function Get-BuildError([Parameter(Mandatory=1)][string]$Task) {
+	if (!($_ = ${*}.All[$Task])) {
+		*Die "Missing task '$Task'." 5
+	}
+	$_.Error
+}
+
+#.ExternalHelp Help.xml
+function Get-BuildFile($Path, [switch]$Here) {
+	do {
+		if (($f = [System.IO.Directory]::GetFiles($Path, '*.build.ps1')).Length -eq 1) {return $f}
+		if ($f) {return $($f | Sort-Object)[0]}
+		if (($c = $env:InvokeBuildGetFile) -and ($f = & $c $Path)) {return $f}
+	} while(!$Here -and ($Path = Split-Path $Path))
+}
+
+#.ExternalHelp Help.xml
+function Get-BuildProperty([Parameter(Mandatory=1)][string]$Name, $Value, [switch]$Boolean) {
+	${*n} = $Name
+	${*v} = $Value
+	Remove-Variable Name, Value
+	$_ = if (($null -ne ($_ = $PSCmdlet.GetVariableValue(${*n})) -and '' -ne $_) -or ($_ = [Environment]::GetEnvironmentVariable(${*n}))) {$_}
+	elseif ($null -eq ${*v}) {*Die "Missing property '${*n}'." 13}
+	else {${*v}}
+	if ($Boolean) {if (1 -eq $_) {$true} elseif (0 -eq $_) {$false} else {[System.Convert]::ToBoolean($_)}} else {$_}
+}
+
+#.ExternalHelp Help.xml
+function Get-BuildSynopsis([Parameter(Mandatory=1)]$Task, $Hash=${*}.H) {
+	$f = ($I = $Task.InvocationInfo).ScriptName
+	if (!($d = $Hash[$f])) {
+		$Hash[$f] = $d = @{T = Get-Content -LiteralPath $f; C = @{}}
+		foreach($_ in [System.Management.Automation.PSParser]::Tokenize($d.T, [ref]$null)) {
+			if ($_.Type -eq 15) {$d.C[$_.EndLine] = $_.Content}
+		}
+	}
+	for($n = $I.ScriptLineNumber; --$n -ge 1) {
+		if ($c = $d.C[$n]) {if ($c -match '(?m)^\s*(?:#*\s*Synopsis\s*:|\.Synopsis\s*^)(.*)') {return $Matches[1].Trim()}}
+		elseif ($d.T[$n - 1].Trim()) {break}
+	}
+}
+
+#.ExternalHelp Help.xml
+function Get-BuildVersion([Parameter(Mandatory=1)][string]$Path, [Parameter(Mandatory=1)]$Regex) {
+	trap {*Die $_ 5}
+	foreach($_ in [System.IO.File]::ReadAllLines($PSCmdlet.GetUnresolvedProviderPathFromPSPath($Path))) {
+		if ($_ -match $Regex) {
+			return $Matches[1]
+		}
+	}
+	throw "Cannot find version in '$Path'."
+}
+
+#.ExternalHelp Help.xml
+function Invoke-BuildExec([Parameter(Mandatory=1)][scriptblock]$Command, [int[]]$ExitCode=0, [string]$ErrorMessage, [switch]$Echo, [switch]$StdErr) {
+	${private:*c} = $Command
+	${private:*x} = $ExitCode
+	${private:*m} = $ErrorMessage
+	${private:*v} = $Echo
+	${private:*s} = $StdErr
+	${private:*e} = ''
+	Remove-Variable Command, ExitCode, ErrorMessage, Echo, StdErr
+	if (${*v}) {
+		*Echo ${*c}
+	}
+
+	$global:LastExitCode = 0
+	if (${*s}) {
+		$ErrorActionPreference = 2
+		try {
+			& ${*c} 2>&1 | .{process{
+				if ($_ -is [System.Management.Automation.ErrorRecord]) {
+					$_ = $_.Exception.Message
+					${*e} += "`n$_"
+				}
+				$_
+			}}
+		}
+		catch {throw}
+	}
+	else {
+		& ${*c}
+	}
+
+	if (${*x} -notcontains $global:LastExitCode) {
+		*Die "$(if (${*m}) {"${*m} "})Command exited with code $global:LastExitCode. {${*c}}${*e}" 8
+	}
+}
+
+#.ExternalHelp Help.xml
+function Remove-BuildItem([Parameter(Mandatory=1)][string[]]$Path) {
+	if ($Path -match '^[.*/\\]*$') {*Die 'Not allowed paths.' 5}
+	$v = $PSBoundParameters['Verbose']
+	$p = @{Force=$true; Recurse=$true}
+	if ($PSVersionTable.PSVersion -ge ([version]'7.4')) {$p.ProgressAction='Ignore'}
+	try {
+		foreach($_ in $Path) {
+			if (Get-Item $_ -Force -ErrorAction 0) {
+				if ($v) {Write-Verbose "remove: removing $_" -Verbose}
+				Remove-Item $_ @p
+			}
+			elseif ($v) {Write-Verbose "remove: skipping $_" -Verbose}
+		}
+	}
+	catch {
+		*Die $_
+	}
+}
+
+#.ExternalHelp Help.xml
+function Set-BuildFooter([Parameter()][scriptblock]$Script) {
+	${*}.Footer = $Script
+}
+
+#.ExternalHelp Help.xml
+function Set-BuildHeader([Parameter()][scriptblock]$Script) {
+	${*}.Header = $Script
+}
+
+#.ExternalHelp Help.xml
+function Test-BuildAsset(
+	[ValidateNotNullOrEmpty()][string[]][Parameter(Position=0)]$Variable,
+	[ValidateNotNullOrEmpty()][string[]]$Environment,
+	[ValidateNotNullOrEmpty()][string[]]$Property,
+	[ValidateNotNullOrEmpty()][string[]]$Path
+) {
+	${*v} = $Variable
+	${*e} = $Environment
+	${*p} = $Property
+	${*f} = $Path
+	Remove-Variable Variable, Environment, Property, Path
+	foreach($_ in ${*v}) {
+		if ($null -eq ($$ = $PSCmdlet.GetVariableValue($_)) -or '' -eq $$) {*Die "Missing variable '$_'." 13}
+	}
+	foreach($_ in ${*e}) {
+		if (!([Environment]::GetEnvironmentVariable($_))) {*Die "Missing environment variable '$_'." 13}
+	}
+	foreach($_ in ${*p}) {
+		if ('' -eq (Get-BuildProperty $_ '')) {*Die "Missing property '$_'." 13}
+	}
+	foreach($_ in ${*f}) {
+		if (!(Test-Path -LiteralPath $_)) {*Die "Missing path '$_'." 13}
+	}
+}
+
+#.ExternalHelp Help.xml
+function Use-BuildAlias([Parameter(Mandatory=1)][string]$Path, [string[]]$Name) {
+	trap {*Die $_ 5}
+	$d = switch -regex ($Path) {
+		'^\*|^\d+\.' {Split-Path (Resolve-MSBuild $_)}
+		^Framework {"$env:windir\Microsoft.NET\$_"}
+		default {*Path $_}
+	}
+	if (![System.IO.Directory]::Exists($d)) {throw "Cannot resolve '$Path'."}
+	foreach($_ in $Name) {
+		Set-Alias $_ (Join-Path $d $_) -Scope 1
+	}
+}
+
+#.ExternalHelp Help.xml
+function Use-BuildEnv([Parameter(Mandatory=1)][hashtable]$Env, [Parameter(Mandatory=1)][scriptblock]$Script) {
+	${private:*e} = @{}
+	${private:*s} = $Script
+	function *set($n, $v) {
+		[Environment]::SetEnvironmentVariable($n, $(if ($null -eq $v) {[System.Management.Automation.Language.NullString]::Value} else {$v}))
+	}
+	foreach($_ in $Env.GetEnumerator()) {
+		${*e}[$_.Key] = [Environment]::GetEnvironmentVariable($_.Key)
+		*set $_.Key $_.Value
+	}
+	Remove-Variable Env, Script
+	try {
+		& ${*s}
+	}
+	finally {
+		foreach($_ in ${*e}.GetEnumerator()) {
+			*set $_.Key $_.Value
+		}
+	}
+}
+
+#.ExternalHelp Help.xml
+function Write-Build([ConsoleColor]$Color, [string]$Text) {
+	*Write $Color ($Text -split '\r\n|[\r\n]')
+}
+
+function *Msg($M, $I) {
+	"$M`n$(*At $I)"
+}
+
+function *Path($P) {
+	$PSCmdlet.GetUnresolvedProviderPathFromPSPath($P)
+}
+
+if ($PSVersionTable.PSVersion -ge [Version]'7.2' -and $PSStyle.OutputRendering -ne 'PlainText' -and !$env:MSBuildLoadMicrosoftTargetsReadOnly) {
+	function *Write($C, $T) {
+		$f = "`e[$((30,34,32,36,31,35,33,37,90,94,92,96,91,95,93,97)[$C])m{0}`e[0m"
+		foreach($_ in $T) {
+			$f -f $_
+		}
+	}
+}
+else {
+	function *Write($C, $T) {
+		$i = $Host.UI.RawUI
+		$_ = $i.ForegroundColor
+		try {
+			$i.ForegroundColor = $C
+			$T
+		}
+		finally {
+			$i.ForegroundColor = $_
+		}
+	}
+	try {
+		$null = *Write 0
+	}
+	catch {
+		function *Write {$args[1]}
+	}
+}
+
+### init
+if ($MyInvocation.InvocationName -eq '.') {return}
+${private:*p} = if ($_ = $PSCmdlet.SessionState.PSVariable.Get('*')) {if ($_.Description -eq 'IB') {$_.Value}}
+New-Variable * -Description IB ([PSCustomObject]@{
+	All = [ordered]@{}
+	Tasks = [System.Collections.Generic.List[object]]@()
+	Errors = [System.Collections.Generic.List[object]]@()
+	Warnings = [System.Collections.Generic.List[object]]@()
+	Redefined = @()
+	Doubles = @()
+	Started = [DateTime]::Now
+	Elapsed = $null
+	Error = 'Invalid arguments.'
+	Task = $null
+	File = $BuildFile = $PSBoundParameters['File']
+	Safe = $PSBoundParameters['Safe']
+	Summary = $PSBoundParameters['Summary']
+	CD = $OriginalLocation = *Path
+	DP = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+	BB = [System.Collections.Generic.List[object]]@()
+	B1 = $null
+	P = ${*p}
+	A = 1
+	B = 0
+	Q = 0
+	H = @{}
+	Header = if (${*p}) {${*p}.Header} else {{print 11 "Task $($args[0])"}}
+	Footer = if (${*p}) {${*p}.Footer} else {{print 11 "Done $($args[0]) $($Task.Elapsed)"}}
+	Data = @{}
+	XBuild = $null
+	XCheck = $null
+})
+
+if ($_ = $PSBoundParameters['Result']) {
+	if ($_ -is [string]) {
+		New-Variable $_ ${*} -Scope 1 -Force
+	}
+	elseif ($_ -is [hashtable]) {
+		${*}.XBuild = $_['XBuild']
+		${*}.XCheck = $_['XCheck']
+		$_.Value = ${*}
+	}
+	else {throw 'Invalid parameter Result.'}
+}
+
+function *BB($FS, $PX, $BR) {
+	$_ = if ($FS -is [string]) {$FS} else {$FS.File}
+	@{FS=$FS; PX=$PX; BR=@(if ($_) {Split-Path $_} else {${*}.CD}; $BR); DP=@{}; EnterBuild=$null; ExitBuild=$null; EnterTask=$null; ExitTask=$null; EnterJob=$null; ExitJob=$null}
+}
+
+$BuildTask = $PSBoundParameters['Task']
+if ($BuildFile -is [scriptblock]) {
+	${*}.BB.Add((*BB $BuildFile '' @()))
+	$BuildFile = $BuildFile.File
+	return
+}
+
+if ($BuildTask -eq '**') {
+	if (![System.IO.Directory]::Exists(($_ = *Path $BuildFile))) {throw "Missing directory '$_'."}
+	$BuildFile = @(Get-ChildItem -LiteralPath $_ -Filter *.test.ps1 -Recurse -Force)
+	return
+}
+
+if ($BuildFile) {
+	if (![System.IO.File]::Exists(($BuildFile = *Path $BuildFile))) {
+		if (![System.IO.Directory]::Exists($BuildFile)) {throw "Missing script '$BuildFile'."}
+		if (!($_ = Get-BuildFile $BuildFile -Here)) {throw "Missing script in '$BuildFile'."}
+		$BuildFile = $_
+	}
+}
+elseif (!($BuildFile = Get-BuildFile ${*}.CD)) {
+	throw 'Missing default script.'
+}
+${*}.File = $BuildFile
+
+### param
+function *DP($FS, $PX, $BR) {
+	if (!($p = (Get-Command $FS -ErrorAction 1).Parameters)) {throw & $FS}
+	$b = *BB $FS $PX $BR
+	if ($p.get_Count()) {
+		$c = 'Verbose', 'Debug', 'ErrorAction', 'WarningAction', 'ErrorVariable', 'WarningVariable', 'OutVariable', 'OutBuffer', 'PipelineVariable', 'InformationAction', 'InformationVariable', 'ProgressAction'
+		$r = 'Task', 'File', 'Result', 'Safe', 'Summary', 'WhatIf'
+		:param foreach($p in $p.get_Values()) {
+			if (($n = $p.Name) -in $c) {continue}
+			if ($n -in $r) {throw "Script uses reserved parameter '$n'."}
+			foreach ($a in $p.Attributes) {
+				if ($a -is [System.Management.Automation.ValidateScriptAttribute]) {if ($n -eq 'Extends') {
+					foreach($s in & $a.ScriptBlock) {
+						$x = ''
+						if (($_ = $s.IndexOf('::')) -ge 0) {
+							$x = $s.Substring(0, $_ + 2)
+							$s = $s.Substring($_ + 2)
+						}
+						$s = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($b.BR[0], $s))
+						try {*DP $s $x $b.BR} catch {throw "Parameter 'Extends': $_"}
+					}
+					continue param
+				}}
+				elseif ($a -is [System.Management.Automation.ParameterAttribute]) {if ($a.Position -ge 0) {
+					$a.Position += 2
+				}}
+			}
+			$_ = New-Object System.Management.Automation.RuntimeDefinedParameter $n, $p.ParameterType, $p.Attributes
+			$b.DP[$n] = $_
+			${*}.DP[$n] = $_
+		}
+	}
+	${*}.BB.Add($b)
+}
+*DP $BuildFile '' @()
+${*}.DP
+}
+end {
+Remove-Variable Task, File, Result, Safe, Summary
+if ($MyInvocation.InvocationName -eq '.') {
+	Remove-Variable WhatIf
+	return
+}
+
+function Enter-Build([Parameter()][scriptblock]$Script) {${*}.B1.EnterBuild = $Script}
+function Exit-Build([Parameter()][scriptblock]$Script) {${*}.B1.ExitBuild = $Script}
+function Enter-BuildTask([Parameter()][scriptblock]$Script) {${*}.B1.EnterTask = $Script}
+function Exit-BuildTask([Parameter()][scriptblock]$Script) {${*}.B1.ExitTask = $Script}
+function Enter-BuildJob([Parameter()][scriptblock]$Script) {${*}.B1.EnterJob = $Script}
+function Exit-BuildJob([Parameter()][scriptblock]$Script) {${*}.B1.ExitJob = $Script}
+function Set-BuildData([Parameter()]$Key, $Value) {${*}.Data[$Key] = $Value}
+
+function Write-Warning([Parameter()]$Message) {
+	$PSCmdlet.WriteWarning($Message)
+	${*}.Warnings.Add([PSCustomObject]@{Message = $Message; File = $BuildFile; Task = ${*}.Task; InvocationInfo=$MyInvocation})
+}
+
+function *Amend($X, $J, $B) {
+	$n = $X.Name
+	foreach($_ in $J) {
+		$r, $s = *Job $_
+		if (!($t = ${*}.All[$r])) {*Fin (*Msg "Task '$n': Missing task '$r'." $X) 5}
+		$j = $t.Jobs
+		$i = $j.Count
+		if ($B) {
+			for($k = -1; ++$k -lt $i -and $j[$k] -is [string]) {}
+			$i = $k
+		}
+		$j.Insert($i, $(if ($s) {"?$n"} else {$n}))
+	}
+}
+
+function *At($I) {
+	$I.InvocationInfo.PositionMessage.Trim()
+}
+
+function *Check($J, $T, $P=@()) {
+	foreach($_ in $J) {if ($_ -is [string]) {
+		$_ = $_.TrimStart('?')
+		if (!($r = ${*}.All[$_])) {
+			$_ = "Missing task '$_'."
+			*Fin $(if ($T) {*Msg "Task '$($T.Name)': $_" $T} else {"File '$BuildFile': $_"}) 5
+		}
+		if ($r -in $P) {
+			*Fin (*Msg "Task '$($T.Name)': Cyclic reference to '$_'." $T) 5
+		}
+		*Check $r.Jobs $r ($P + $r)
+	}}
+}
+
+function *Echo {
+	${*c} = $args[0]
+	${*t} = "${*c}".Replace("`t", '    ')
+	print 3 "exec {$(if (${*t} -match '((?:\r\n|[\r\n]) *)\S') {"$(${*t}.TrimEnd().Replace($matches[1], "`n    "))`n"} else {${*t}})}"
+	print 8 "cd $global:pwd"
+	foreach(${*v} in ${*c}.Ast.FindAll({$args[0] -is [System.Management.Automation.Language.VariableExpressionAst]}, $true)) {
+		${*p} = ${*v}.Parent
+		if (${*p} -is [System.Management.Automation.Language.MemberExpressionAst]) {
+			if (${*p} -is [System.Management.Automation.Language.InvokeMemberExpressionAst]) {continue}
+			${*v} = ${*p}
+		}
+		if (${*v}.Parent -isnot [System.Management.Automation.Language.AssignmentStatementAst]) {
+			${*t} = "${*v}" -replace '^@', '$'
+			print 8 "${*t}: $(& ([scriptblock]::Create(${*t})))"
+		}
+	}
+}
+
+function *Err($T) {
+	${*}.Errors.Add([PSCustomObject]@{Error = $_; File = $BuildFile; Task = $T})
+	print 12 "ERROR: $(if (*My) {$_} else {*Msg $_ $_})"
+	if ($T) {$T.Error = $_}
+}
+
+function *Fin([Parameter()]$M, $C=0) {
+	*Die $M $C
+}
+
+function *Help {process{
+	[PSCustomObject]@{
+		Name = $_.Name
+		Synopsis = Get-BuildSynopsis $_
+		Jobs = foreach($j in $_.Jobs) {if ($j -is [string]) {$j} else {'{}'}}
+	}
+}}
+
+function *IO {
+	if ((${private:*i} = $Task.Inputs) -is [scriptblock]) {
+		*SL
+		${*i} = @(& ${*i})
+	}
+	*SL
+	${private:*p} = [System.Collections.Generic.List[object]]@()
+	${*i} = foreach($_ in ${*i}) {
+		if ($_ -isnot [System.IO.FileInfo]) {$_ = [System.IO.FileInfo](*Path $_)}
+		if (!$_.Exists) {*Fin "Missing input '$_'." 13}
+		${*p}.Add($_.FullName)
+		$_
+	}
+	if (!${*p}) {return 2, 'Skipping empty input.'}
+
+	${private:*o} = $Task.Outputs
+	if ($Task.Partial) {
+		${*o} = @(
+			if (${*o} -is [scriptblock]) {
+				${*p} | & ${*o}
+				*SL
+			}
+			else {
+				${*o}
+			}
+		)
+		if (${*p}.Count -ne ${*o}.Count) {*Fin "Different Inputs/Outputs counts: $(${*p}.Count)/$(${*o}.Count)." 6}
+
+		$k = -1
+		$Task.Inputs = $i = [System.Collections.Generic.List[object]]@()
+		$Task.Outputs = $o = [System.Collections.Generic.List[object]]@()
+		foreach($_ in ${*i}) {
+			$f = *Path ($p = ${*o}[++$k])
+			if (![System.IO.File]::Exists($f) -or $_.LastWriteTime -gt [System.IO.File]::GetLastWriteTime($f)) {
+				$i.Add(${*p}[$k])
+				$o.Add($p)
+			}
+		}
+		if ($i) {return $null, "Out-of-date outputs: $($o.Count)/$(${*p}.Count)."}
+	}
+	else {
+		if (${*o} -is [scriptblock]) {
+			$Task.Outputs = ${*o} = ${*p} | & ${*o}
+			*SL
+		}
+		if (!${*o}) {*Fin 'Outputs must not be empty.' 5}
+
+		$Task.Inputs = ${*p}
+		$m = (${*i} | .{process{$_.LastWriteTime.Ticks}} | Measure-Object -Maximum).Maximum
+		foreach($_ in ${*o}) {
+			$p = *Path $_
+			if (![System.IO.File]::Exists($p)) {return $null, "Missing output '$_'."}
+			if ($m -gt [System.IO.File]::GetLastWriteTime($p).Ticks) {return $null, "Out-of-date output '$_'."}
+		}
+	}
+	2, 'Skipping up-to-date output.'
+}
+
+function *Job($J) {
+	if ($J -is [string]) {if ($J[0] -eq '?') {$J.Substring(1), 1} else {$J}}
+	elseif ($J -is [scriptblock]) {$J}
+	else {*Fin 'Invalid job.' 5}
+}
+
+function *My {
+	$_.InvocationInfo.ScriptName -eq $MyInvocation.ScriptName
+}
+
+function *Root {
+	$t = foreach($_ in ${*}.All.get_Values()) {if ($_.InvocationInfo.ScriptName -eq $BuildFile -and $_.Name -ne '.') {$_}}
+	$n = foreach($_ in $t) {$_.Name}
+	*Check $n
+	$j = foreach($_ in $t) {foreach($_ in $_.Jobs) {if ($_ -is [string]) {$_.TrimStart('?')}}}
+	foreach($_ in $n) {if ($_ -notin $j) {$_}}
+}
+
+function *Run($_) {if ($_) {
+	*SL
+	. $_ @args
+}}
+
+function *SL($P=$BuildRoot) {
+	Set-Location -LiteralPath $P -ErrorAction 1
+}
+
+function *Task {
+	${private:*p} = "$($args[1])/$($args[0])"
+	${private:*n}, ${private:*s} = *Job $args[0]
+	New-Variable Task (${*}.Task = ${*}.All[${*n}]) -Option Constant
+
+	if ($Task.Elapsed) {
+		print 8 "Done ${*p}"
+		return
+	}
+
+	$BuildRoot = $Task.B1.BR[0]
+	$Task.Started = [DateTime]::Now
+	if ((${private:*x} = $Task.If) -is [scriptblock]) {
+		*SL
+		try {
+			${*x} = & ${*x}
+		}
+		catch {
+			*Err $Task
+			print 8 (*At $Task)
+			${*}.Tasks.Add($Task)
+			$Task.Elapsed = [TimeSpan]::Zero
+			throw
+		}
+	}
+	if (!${*x}) {
+		print 8 "Task ${*p} skipped."
+		return
+	}
+
+	${private:*i} = , [int]($null -ne $Task.Inputs)
+	try {
+		. *Run $Task.B1.EnterTask
+		foreach($_ in $Task.Jobs) {
+			if ($_ -is [string]) {
+				try {
+					*Task $_ ${*p}
+				}
+				finally {
+					${*}.Task = $Task
+				}
+				continue
+			}
+			New-Variable Job $_ -Option ReadOnly -Force
+			& ${*}.Header ${*p}
+
+			if (1 -eq ${*i}[0]) {
+				try {
+					${*i} = *IO
+				}
+				catch {
+					*Err $Task
+					throw
+				}
+				print 8 ${*i}[1]
+			}
+			if (${*i}[0]) {
+				continue
+			}
+
+			try {
+				. *Run $Task.B1.EnterJob
+				*SL
+				if (0 -eq ${*i}[0]) {
+					& $Job
+				}
+				else {
+					$Inputs = $Task.Inputs
+					$Outputs = $Task.Outputs
+					if ($Task.Partial) {
+						${*x} = 0
+						$Inputs | .{process{
+							$2 = $Outputs[${*x}++]
+							$_
+						}} | & $Job
+					}
+					else {
+						$Inputs | & $Job
+					}
+				}
+			}
+			catch {
+				*Err $Task
+				print 8 (*At $Task)
+				throw
+			}
+			finally {
+				. *Run $Task.B1.ExitJob
+			}
+		}
+	}
+	catch {
+		$Task.Error = $_
+		if (!${*s} -or (*Unsafe ${*n} $BuildTask)) {throw}
+	}
+	finally {
+		$Task.Elapsed = [DateTime]::Now - $Task.Started
+		${*}.Tasks.Add($Task)
+		if (!$Task.Error) {
+			if (${*}.XCheck) {& ${*}.XCheck}
+			& ${*}.Footer ${*p}
+		}
+		*Run $Task.Done
+		. *Run $Task.B1.ExitTask
+	}
+}
+
+function *Unsafe($N, $J) {
+	if ($N -in $J) {return 1}
+	foreach($_ in $J) {if ($_ -is [string]) {
+		$_ = $_.TrimStart('?')
+		if ($_ -ne $N -and ($t = ${*}.All[$_]) -and $t.If -and (*Unsafe $N $t.Jobs)) {return 1}
+	}}
+}
+
+function *What {
+	& $PSScriptRoot/Show-TaskHelp.ps1
+}
+
+$ErrorActionPreference=1
+if (${*}.Q = $BuildTask -eq '?' -or $BuildTask -eq '??') {
+	$WhatIf = $true
+}
+
+${*}.Error = $null
+try {
+	if ($BuildTask -eq '**') {
+		${*}.A = 0
+		foreach($_ in $BuildFile) {
+			Invoke-Build * $_.FullName -Safe:${*}.Safe
+		}
+		${*}.B = 1
+		exit
+	}
+
+	### load
+	New-Variable Task @{Name = $BuildFile} -Option Constant
+	${*p} = @(foreach($_ in ${*}.DP.get_Values()) {if ($_.IsSet) {$_}})
+	${private:**} = @(
+		foreach(${private:*b} in ${*}.BB) {
+			${*}.B1 = ${*b}
+			${private:*s} = @{}
+			foreach($_ in ${*p}) {
+				if (${*b}.DP.ContainsKey($_.Name)) {
+					${*s}[$_.Name] = $_.Value
+				}
+			}
+			$BuildRoots = @(${*b}.BR)
+			$BuildRoot = $BuildRoots[0]
+			*SL
+			$_ = ${*s}
+			. ${*b}.FS @_
+			if (![System.IO.Directory]::Exists(($_ = *Path $BuildRoot))) {*Fin "Missing build root '$BuildRoot'." 13}
+			${*b}.BR[0] = $_
+		}
+	)
+	Remove-Variable BuildRoots
+	foreach($_ in ${**}) {
+		Write-Warning "Unexpected output: $_."
+		if ($_ -is [scriptblock]) {*Fin "Dangling scriptblock at $($_.File):$($_.StartPosition.StartLine)" 6}
+	}
+	if (!(${**} = ${*}.All).get_Count()) {*Fin "No tasks in '$BuildFile'." 6}
+
+	foreach($_ in ${**}.get_Values()) {
+		if ($_.Before) {*Amend $_ $_.Before 1}
+	}
+	foreach($_ in ${**}.get_Values()) {
+		if ($_.After) {*Amend $_ $_.After}
+	}
+
+	if (${*}.Q) {
+		*Check ${**}.get_Keys()
+		if ($BuildTask -eq '?') {
+			${**}.get_Values() | *Help
+		}
+		else {
+			${**}
+		}
+		exit
+	}
+
+	if ($BuildTask -eq '*') {
+		$BuildTask = *Root
+	}
+	else {
+		if (!$BuildTask -or '.' -eq $BuildTask) {
+			$BuildTask = if (${**}['.']) {'.'} else {${**}.Item(0).Name}
+		}
+		*Check $BuildTask
+	}
+	if ($WhatIf) {
+		*What
+		exit
+	}
+
+	print 11 "Build $($BuildTask -join ', ') $BuildFile"
+	foreach($_ in ${*}.Redefined) {
+		if (($_ = $_.Name) -ne '.') {print 8 "Redefined task '$_'."}
+	}
+	foreach($_ in ${*}.Doubles) {
+		if (${*}.All[$_[1]].If -isnot [scriptblock]) {
+			Write-Warning "Task '$($_[0])' always skips '$($_[1])'."
+		}
+	}
+
+	### build
+	${*}.A = 0
+	try {
+		foreach($_ in ${*}.BB) {
+			$BuildRoot = $_.BR[0]
+			. *Run $_.EnterBuild
+		}
+		if (${*}.XBuild) {. ${*}.XBuild}
+		if (${*}.XCheck) {& ${*}.XCheck}
+		foreach($_ in $BuildTask) {
+			*Task $_ ''
+		}
+	}
+	finally {
+		${*}.Task = $null
+		for($$ = ${*}.BB.Count; --$$ -ge 0) {
+			$BuildRoot = ${*}.BB[$$].BR[0]
+			. *Run ${*}.BB[$$].ExitBuild
+		}
+	}
+	${*}.B = 1
+	exit
+}
+catch {
+	${*}.B = 2
+	${*}.Error = $_
+	if (!${*}.Errors) {*Err}
+	if ($_.FullyQualifiedErrorId -eq 'PositionalParameterNotFound,Add-BuildTask') {
+		Write-Warning 'Check task parameters: Name and comma separated Jobs.'
+	}
+	if (${*}.Safe) {
+		exit
+	}
+	elseif (*My) {
+		$PSCmdlet.ThrowTerminatingError($_)
+	}
+	throw
+}
+finally {
+	*SL ${*}.CD
+	if (${*}.B -and !${*}.Q) {
+		$t = ${*}.Tasks
+		$e = ${*}.Errors
+		if (${*}.Summary) {
+			print 11 'Build summary:'
+			foreach($_ in $t) {
+				'{0,-16} {1} - {2}:{3}' -f $_.Elapsed, $_.Name, $_.InvocationInfo.ScriptName, $_.InvocationInfo.ScriptLineNumber
+				if ($_ = $_.Error) {
+					print 12 "ERROR: $(if (*My) {$_} else {*Msg $_ $_})"
+				}
+			}
+		}
+		if ($w = ${*}.Warnings) {
+			foreach($_ in $w) {
+				"WARNING: $(if ($_.Task) {"/$($_.Task.Name) "})$($_.InvocationInfo.ScriptName):$($_.InvocationInfo.ScriptLineNumber)"
+				print 14 $_.Message
+			}
+		}
+		if ($_ = ${*}.P) {
+			$_.Tasks.AddRange($t)
+			$_.Errors.AddRange($e)
+			$_.Warnings.AddRange($w)
+		}
+		$c, $m = if (${*}.A) {12, "Build ABORTED $BuildFile"}
+		elseif (${*}.B -eq 2) {12, 'Build FAILED'}
+		elseif ($e) {14, 'Build completed with errors'}
+		elseif ($w) {14, 'Build succeeded with warnings'}
+		else {10, 'Build succeeded'}
+		print $c "$m. $($t.Count) tasks, $($e.Count) errors, $($w.Count) warnings $((${*}.Elapsed = [DateTime]::Now - ${*}.Started))"
+	}
+}
+}

--- a/Build/Modules/InvokeBuild/5.14.23/InvokeBuild.psd1
+++ b/Build/Modules/InvokeBuild/5.14.23/InvokeBuild.psd1
@@ -1,0 +1,23 @@
+@{
+	ModuleVersion = '5.14.23'
+	RootModule = 'InvokeBuild.psm1'
+	GUID = 'a0319025-5f1f-47f0-ae8d-9c7e151a5aae'
+	Author = 'Roman Kuzmin'
+	CompanyName = 'Roman Kuzmin'
+	Copyright = '(c) Roman Kuzmin'
+	Description = 'Build and test automation in PowerShell'
+	PowerShellVersion = '3.0'
+	AliasesToExport = 'Invoke-Build', 'Build-Checkpoint', 'Build-Parallel'
+	VariablesToExport = @()
+	FunctionsToExport = @()
+	CmdletsToExport = @()
+	PrivateData = @{
+		PSData = @{
+			Tags = 'Build', 'Test', 'Automation'
+			ProjectUri = 'https://github.com/nightroman/Invoke-Build'
+			LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0'
+			IconUri = 'https://raw.githubusercontent.com/nightroman/Invoke-Build/main/ib.png'
+			ReleaseNotes = 'https://github.com/nightroman/Invoke-Build/blob/main/Release-Notes.md'
+		}
+	}
+}

--- a/Build/Modules/InvokeBuild/5.14.23/InvokeBuild.psm1
+++ b/Build/Modules/InvokeBuild/5.14.23/InvokeBuild.psm1
@@ -1,0 +1,5 @@
+
+Set-Alias -Name Build-Checkpoint -Value (Join-Path $PSScriptRoot Build-Checkpoint.ps1)
+Set-Alias -Name Build-Parallel -Value (Join-Path $PSScriptRoot Build-Parallel.ps1)
+Set-Alias -Name Invoke-Build -Value (Join-Path $PSScriptRoot Invoke-Build.ps1)
+Export-ModuleMember -Alias Build-Checkpoint, Build-Parallel, Invoke-Build

--- a/Build/Modules/InvokeBuild/5.14.23/LICENSE
+++ b/Build/Modules/InvokeBuild/5.14.23/LICENSE
@@ -1,0 +1,178 @@
+Copyright (c) 2011-2025 Roman Kuzmin
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/Build/Modules/InvokeBuild/5.14.23/PSGetModuleInfo.xml
+++ b/Build/Modules/InvokeBuild/5.14.23/PSGetModuleInfo.xml
@@ -1,0 +1,113 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.PSRepositoryItemInfo</T>
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Name">InvokeBuild</S>
+      <S N="Version">5.14.23</S>
+      <S N="Type">Module</S>
+      <S N="Description">Build and test automation in PowerShell</S>
+      <S N="Author">Roman Kuzmin</S>
+      <S N="CompanyName">nightroman</S>
+      <S N="Copyright">(c) Roman Kuzmin</S>
+      <DT N="PublishedDate">2026-01-28T12:51:49-06:00</DT>
+      <Nil N="InstalledDate" />
+      <Nil N="UpdatedDate" />
+      <URI N="LicenseUri">http://www.apache.org/licenses/LICENSE-2.0</URI>
+      <URI N="ProjectUri">https://github.com/nightroman/Invoke-Build</URI>
+      <URI N="IconUri">https://raw.githubusercontent.com/nightroman/Invoke-Build/main/ib.png</URI>
+      <Obj N="Tags" RefId="1">
+        <TN RefId="1">
+          <T>System.Object[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>Build</S>
+          <S>Test</S>
+          <S>Automation</S>
+          <S>PSModule</S>
+        </LST>
+      </Obj>
+      <Obj N="Includes" RefId="2">
+        <TN RefId="2">
+          <T>System.Collections.Hashtable</T>
+          <T>System.Object</T>
+        </TN>
+        <DCT>
+          <En>
+            <S N="Key">Function</S>
+            <Obj N="Value" RefId="3">
+              <TNRef RefId="1" />
+              <LST />
+            </Obj>
+          </En>
+          <En>
+            <S N="Key">Workflow</S>
+            <Ref N="Value" RefId="3" />
+          </En>
+          <En>
+            <S N="Key">Command</S>
+            <Ref N="Value" RefId="3" />
+          </En>
+          <En>
+            <S N="Key">Cmdlet</S>
+            <Ref N="Value" RefId="3" />
+          </En>
+          <En>
+            <S N="Key">DscResource</S>
+            <Ref N="Value" RefId="3" />
+          </En>
+          <En>
+            <S N="Key">RoleCapability</S>
+            <Ref N="Value" RefId="3" />
+          </En>
+        </DCT>
+      </Obj>
+      <Nil N="PowerShellGetFormatVersion" />
+      <S N="ReleaseNotes">https://github.com/nightroman/Invoke-Build/blob/main/Release-Notes.md</S>
+      <Obj N="Dependencies" RefId="4">
+        <TNRef RefId="1" />
+        <LST />
+      </Obj>
+      <S N="RepositorySourceLocation">https://www.powershellgallery.com/api/v2</S>
+      <S N="Repository">PSGallery</S>
+      <S N="PackageManagementProvider">NuGet</S>
+      <Obj N="AdditionalMetadata" RefId="5">
+        <TN RefId="3">
+          <T>System.Management.Automation.PSCustomObject</T>
+          <T>System.Object</T>
+        </TN>
+        <MS>
+          <S N="copyright">(c) Roman Kuzmin</S>
+          <S N="description">Build and test automation in PowerShell</S>
+          <S N="requireLicenseAcceptance">False</S>
+          <S N="releaseNotes">https://github.com/nightroman/Invoke-Build/blob/main/Release-Notes.md</S>
+          <S N="isLatestVersion">True</S>
+          <S N="isAbsoluteLatestVersion">True</S>
+          <S N="versionDownloadCount">264463</S>
+          <S N="downloadCount">2999721</S>
+          <S N="packageSize">42600</S>
+          <S N="published">2026-01-28 12:51:49 PM -06:00</S>
+          <S N="created">2026-01-28 12:51:49 PM -06:00</S>
+          <S N="lastUpdated">2026-07-21 5:41:50 PM -05:00</S>
+          <S N="tags">Build Test Automation PSModule</S>
+          <S N="developmentDependency">False</S>
+          <S N="updated">2026-07-21T17:41:50Z</S>
+          <S N="NormalizedVersion">5.14.23</S>
+          <S N="Authors">Roman Kuzmin</S>
+          <S N="IsPrerelease">false</S>
+          <S N="ItemType">Module</S>
+          <S N="FileList">InvokeBuild.nuspec|about_InvokeBuild.help.txt|Build-Checkpoint.ps1|Build-Parallel.ps1|Help.xml|Invoke-Build.ps1|InvokeBuild.psd1|InvokeBuild.psm1|LICENSE|README.html|Resolve-MSBuild.ps1|Show-TaskHelp.ps1</S>
+          <S N="GUID">a0319025-5f1f-47f0-ae8d-9c7e151a5aae</S>
+          <S N="PowerShellVersion">3.0</S>
+          <S N="CompanyName">Roman Kuzmin</S>
+        </MS>
+      </Obj>
+      <S N="InstalledLocation">D:\copilot\copilot-worktrees\powershell-pro-tools\adamdriscoll-ubiquitous-waddle\Build\Modules\InvokeBuild\5.14.23</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Build/Modules/InvokeBuild/5.14.23/README.html
+++ b/Build/Modules/InvokeBuild/5.14.23/README.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>README</title>
+  <style>
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    svg {
+      height: auto;
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
+      font-size: 85%;
+      margin: 0;
+      hyphens: manual;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      border: none;
+      border-top: 1px solid #1a1a1a;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+</head>
+<body>
+<p><a href="https://www.powershellgallery.com/packages/InvokeBuild"><img
+src="https://img.shields.io/powershellgallery/v/InvokeBuild"
+alt="PSGV" /><img
+src="https://img.shields.io/powershellgallery/dt/InvokeBuild"
+alt="PSGD" /></a> <a
+href="https://www.nuget.org/packages/Invoke-Build"><img
+src="https://img.shields.io/nuget/v/Invoke-Build" alt="NGV" /><img
+src="https://img.shields.io/nuget/dt/Invoke-Build" alt="NGD" /></a>
+<img src="https://raw.githubusercontent.com/nightroman/Invoke-Build/main/ib.png" align="right"/></p>
+<h2 id="build-automation-in-powershell">Build Automation in
+PowerShell</h2>
+<p>Invoke-Build is a build and test automation tool which invokes tasks
+defined in PowerShell v3.0+ scripts. It is similar to psake but arguably
+easier to use and more powerful. It is complete, bug free, well covered
+by tests.</p>
+<p>In addition to basic task processing the engine supports</p>
+<ul>
+<li>Incremental tasks with effectively processed inputs and
+outputs.</li>
+<li>Persistent builds which can be resumed after interruptions.</li>
+<li>Parallel builds in separate workspaces with common stats.</li>
+<li>Batch invocation of tests composed as tasks.</li>
+<li>Ability to define new classes of tasks.</li>
+</ul>
+<p>Invoke-Build v3.0.1+ is cross-platform with PowerShell Core.</p>
+<p>Invoke-Build can be effectively used in VSCode and ISE.</p>
+<p>Several <em>PowerShell Team</em> projects use Invoke-Build.</p>
+<h2 id="the-package">The package</h2>
+<p>The package includes the engine, helpers, and help:</p>
+<ul>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Invoke-Build.ps1">Invoke-Build.ps1</a>
+- invokes build scripts, this is the build engine</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Build-Checkpoint.ps1">Build-Checkpoint.ps1</a>
+- invokes persistent builds using the engine</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Build-Parallel.ps1">Build-Parallel.ps1</a>
+- invokes parallel builds using the engine</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Resolve-MSBuild.ps1">Resolve-MSBuild.ps1</a>
+- finds the specified or latest MSBuild</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Show-TaskHelp.ps1">Show-TaskHelp.ps1</a>
+- shows task help, used on WhatIf calls</li>
+<li><code>about_InvokeBuild.help.txt</code> - module help file</li>
+<li><code>Help.xml</code> - content for Get-Help</li>
+</ul>
+<p>Extra scripts, see PSGallery and the repository:</p>
+<ul>
+<li><a
+href="https://www.powershellgallery.com/packages/Invoke-Build.ArgumentCompleters">Invoke-Build.ArgumentCompleters</a>
+- completers for v5 native, TabExpansion2.ps1</li>
+<li><a
+href="https://www.powershellgallery.com/packages/Invoke-TaskFromVSCode">Invoke-TaskFromVSCode</a>
+- invokes a task from a build script opened in VSCode</li>
+<li><a
+href="https://www.powershellgallery.com/packages/Show-BuildGraph">Show-BuildGraph</a>
+- shows task graph by Graphviz Viz.js or dot</li>
+<li><a
+href="https://www.powershellgallery.com/packages/New-VSCodeTask">New-VSCodeTask</a>
+- generates VSCode tasks bound to build script tasks</li>
+<li><a
+href="https://www.powershellgallery.com/packages/Invoke-TaskFromISE">Invoke-TaskFromISE</a>
+- invokes a task from a script opened in ISE</li>
+</ul>
+<p>And some more tools, see the repository:</p>
+<ul>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/ib.cmd">ib.cmd</a>,
+<a
+href="https://github.com/nightroman/Invoke-Build/blob/main/ib.sh">ib.sh</a>
+- cmd and bash helpers</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Build-JustTask.ps1">Build-JustTask.ps1</a>
+- invokes tasks without references</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Convert-psake.ps1">Convert-psake.ps1</a>
+- converts psake build scripts</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Show-BuildTree.ps1">Show-BuildTree.ps1</a>
+- shows task trees as text</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Show-BuildDgml.ps1">Show-BuildDgml.ps1</a>
+- shows task graph as DGML</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Show-BuildMermaid.ps1">Show-BuildMermaid.ps1</a>
+- shows task graph by Mermaid</li>
+</ul>
+<h2 id="install-as-module">Install as module</h2>
+<p>Invoke-Build is published as PSGallery module <a
+href="https://www.powershellgallery.com/packages/InvokeBuild">InvokeBuild</a>.
+You can install it by one of these commands:</p>
+<pre><code>Install-Module InvokeBuild</code></pre>
+<p>To install the module with Chocolatey, run the following command:</p>
+<pre><code>choco install invoke-build</code></pre>
+<p>NOTE: The Chocolatey package is maintained by its owner.</p>
+<h2 id="install-as-scripts">Install as scripts</h2>
+<p>Invoke-Build is also published as <a
+href="https://www.nuget.org/packages/Invoke-Build">nuget.org/packages/Invoke-Build</a>.</p>
+<p>If you use <a href="https://github.com/lukesampson/scoop">scoop</a>
+then invoke:</p>
+<pre><code>scoop install invoke-build</code></pre>
+<p>and you are done, scripts are downloaded and their directory is added
+to the path. You may need to start a new PowerShell session with the
+updated path.</p>
+<p>Otherwise, download the package manually, rename it to zip, extract
+its <em>tools</em> and rename to <em>InvokeBuild</em>. Consider
+including this directory to the path for invoking scripts by names. Or
+copy to any PowerShell module directory in order to use it as
+module.</p>
+<h2 id="install-as-dotnet-tool">Install as dotnet tool</h2>
+<p><a href="https://www.nuget.org/packages/ib">nuget.org/packages/ib</a>
+provides Invoke-Build as the dotnet tool <code>ib</code> which may be
+installed as global or local.</p>
+<p>To install the global tool:</p>
+<pre><code>dotnet tool install --global ib</code></pre>
+<p>To install the local tool:</p>
+<pre><code>dotnet new tool-manifest # once on setting up a repo with tools
+dotnet tool install --local ib</code></pre>
+<p>See <a
+href="https://github.com/nightroman/Invoke-Build/blob/main/ib/README.md">ib/README</a>
+for more details about <code>ib</code> commands.</p>
+<h2 id="getting-help">Getting help</h2>
+<p>If you use the module (known issue <a
+href="https://github.com/PowerShell/PowerShell/issues/2899">#2899</a>)
+or the script is not in the path, use the full path
+<code>help .../Invoke-Build.ps1</code> instead of
+<code>help Invoke-Build</code>.</p>
+<p>In order to get help for the engine, invoke:</p>
+<pre><code>help Invoke-Build -full</code></pre>
+<p>In order to get help for internal commands:</p>
+<pre><code>. Invoke-Build
+help task -full
+help exec -full
+...</code></pre>
+<p>See also online <a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/help/README.md">Invoke-Build
+Help</a></p>
+<h2 id="online-resources">Online resources</h2>
+<ul>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/Concepts.md">Basic
+Concepts</a> Why build scripts may have advantages over normal
+scripts.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/Script-Tutorial.md">Script
+Tutorial</a> Take a look in order to get familiar with build
+scripts.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/tree/main/Tasks/01-step-by-step-tutorial">Step
+by Step Tutorial</a> From "Hello world" to featured scripts.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build.template">Invoke-Build.template</a>
+Create scripts by <code>dotnet new ib</code>.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/Build-Scripts-in-Projects.md">Examples</a>
+Build scripts used in various projects.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/tree/main/Tasks">Tasks</a>
+Samples, patterns, and various techniques.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/Design-Notes.md">Design
+Notes</a> Technical details for contributors.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/README.md">Invoke-Build
+Docs</a> Full documentation.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/help/README.md">Invoke-Build
+Help</a> Commands help.</li>
+<li><a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Release-Notes.md">Release
+Notes</a></li>
+</ul>
+<p>Questions, suggestions, and reports are welcome at <a
+href="https://github.com/nightroman/Invoke-Build/discussions">discussions</a>
+and <a
+href="https://github.com/nightroman/Invoke-Build/issues">issues</a>.</p>
+<h2 id="credits">Credits</h2>
+<ul>
+<li>The project was inspired by <a
+href="https://github.com/psake/psake">psake</a>, see <a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/Comparison-with-psake.md">Comparison
+with psake</a></li>
+<li>Some concepts came from <a
+href="https://github.com/Microsoft/msbuild">MSBuild</a>, see <a
+href="https://github.com/nightroman/Invoke-Build/blob/main/Docs/Comparison-with-MSBuild.md">Comparison
+with MSBuild</a></li>
+</ul>
+</body>
+</html>

--- a/Build/Modules/InvokeBuild/5.14.23/Resolve-MSBuild.ps1
+++ b/Build/Modules/InvokeBuild/5.14.23/Resolve-MSBuild.ps1
@@ -1,0 +1,329 @@
+<#PSScriptInfo
+.VERSION 1.7.2
+.AUTHOR Roman Kuzmin
+.COPYRIGHT (c) Roman Kuzmin
+.TAGS Invoke-Build, MSBuild
+.GUID 53c01926-4fc5-4cbd-aa46-32e415b2373b
+.LICENSEURI http://www.apache.org/licenses/LICENSE-2.0
+.PROJECTURI https://github.com/nightroman/Invoke-Build
+#>
+
+<#
+.Synopsis
+	Finds the specified or latest MSBuild.
+
+.Description
+	The script finds the path to the specified or latest version of MSBuild.
+	Designed for MSBuild 18.0, 17.0, 16.0, 15.0, 14.0, 12.0, 4.0, 3.5, 2.0.
+
+	For MSBuild 15+ the command uses the module VSSetup, see PSGallery.
+	If VSSetup is not installed then the default locations are used.
+	VSSetup is required for not default installations.
+
+	MSBuild 15+ resolution: the latest major version (or absolute if -Latest),
+	then Enterprise, Professional, Community, BuildTools, other products.
+
+	For MSBuild 2.0-14.0 the information is taken from the registry.
+
+.Parameter Version
+		Specifies the required MSBuild major version. If it is omitted, empty,
+		or *, then the command finds and returns the latest installed version.
+		The optional suffix x86 tells to use 32-bit MSBuild.
+		Versions: 18.0, 17.0, 16.0, 15.0, 14.0, 12.0, 4.0, 3.5, 2.0.
+
+.Parameter MinimumVersion
+		Specifies the required minimum MSBuild version. If the resolved version
+		is less than the minimum then the commands terminates with an error.
+
+.Parameter Latest
+		Tells to select the latest minor version if there are 2+ products with
+		the same major version. Note that major versions have higher precedence
+		than products regardless of -Latest.
+
+.Outputs
+	The full path to MSBuild.exe
+
+.Example
+	Resolve-MSBuild 17.0x86
+	Gets the location of 32-bit MSBuild of Visual Studio 2022.
+
+.Example
+	Resolve-MSBuild -MinimumVersion 16.3.1 -Latest
+	Gets the location of the latest MSBuild, and asserts its version is 16.3.1+.
+
+.Example
+	Resolve-MSBuild x86 -MinimumVersion 15.0 -Latest
+	Gets the location of the latest 32-bit MSBuild, and asserts its version is 15.0+.
+
+.Link
+	https://www.powershellgallery.com/packages/VSSetup
+#>
+
+[OutputType([string])]
+[CmdletBinding()]
+param(
+	[string]$Version
+	,
+	[Version]$MinimumVersion
+	,
+	[switch]$Latest
+)
+
+function Get-MSBuild15Path {
+	[CmdletBinding()] param(
+		[string]$Version,
+		[string]$Bitness
+	)
+
+	if ([System.IntPtr]::Size -eq 4 -or $Bitness -eq 'x86') {
+		"MSBuild\$Version\Bin\MSBuild.exe"
+	}
+	else {
+		"MSBuild\$Version\Bin\amd64\MSBuild.exe"
+	}
+}
+
+function Get-MSBuild15VSSetup {
+	[CmdletBinding()] param(
+		[string]$Version,
+		[string]$Bitness,
+		[switch]$Latest,
+		[switch]$Prerelease
+	)
+
+	if (!(Get-Module VSSetup)) {
+		if (!(Get-Module VSSetup -ListAvailable)) {return}
+		Import-Module VSSetup
+	}
+
+	$items = @(
+		$v = switch($Version) {
+			'18.0' {'[18.0,19.0)'}
+			'17.0' {'[17.0,18.0)'}
+			'16.0' {'[16.0,17.0)'}
+			'15.0' {'[15.0,16.0)'}
+			default {'[15.0,)'}
+		}
+		Get-VSSetupInstance -Prerelease:$Prerelease |
+		Select-VSSetupInstance -Version $v -Require Microsoft.Component.MSBuild -Product *
+	)
+	if (!$items) {
+		if (!$Prerelease) {
+			Get-MSBuild15VSSetup $Version $Bitness -Latest:$Latest -Prerelease
+		}
+		return
+	}
+
+	if ($items.Count -ge 2) {
+		$byVersion = if ($Latest) {{$_.InstallationVersion}} else {{$_.InstallationVersion.Major}}
+		$byProduct = {
+			switch ($_.Product.Id) {
+				Microsoft.VisualStudio.Product.Enterprise {4}
+				Microsoft.VisualStudio.Product.Professional {3}
+				Microsoft.VisualStudio.Product.Community {2}
+				Microsoft.VisualStudio.Product.BuildTools {1}
+				default {0}
+			}
+		}
+		$items = $items | Sort-Object $byVersion, $byProduct
+	}
+
+	$item = $items[-1]
+	if ($item.InstallationVersion.Major -eq 15) {
+		$Version = '15.0'
+	}
+	else {
+		$Version = 'Current'
+	}
+	Join-Path $item.InstallationPath (Get-MSBuild15Path $Version $Bitness)
+}
+
+function Get-MSBuild15Guess {
+	[CmdletBinding()] param(
+		[string]$Version,
+		[string]$Bitness,
+		[switch]$Latest,
+		[switch]$Prerelease
+	)
+
+	$Program64 = $env:ProgramFiles
+	if (!($Program86 = ${env:ProgramFiles(x86)})) {$Program86 = $Program64}
+
+	$folders = $(
+		if ($Prerelease) {
+			"$Program64\Microsoft Visual Studio\Preview"
+			"$Program86\Microsoft Visual Studio\Preview"
+		}
+		elseif ($Version -eq '*') {
+			"$Program64\Microsoft Visual Studio\2026"
+			"$Program86\Microsoft Visual Studio\2026"
+			"$Program64\Microsoft Visual Studio\18"
+			"$Program86\Microsoft Visual Studio\18"
+			"$Program64\Microsoft Visual Studio\2022"
+			"$Program86\Microsoft Visual Studio\2022"
+			"$Program86\Microsoft Visual Studio\2019"
+			"$Program86\Microsoft Visual Studio\2017"
+		}
+		elseif ($Version -eq '18.0') {
+			"$Program64\Microsoft Visual Studio\2026"
+			"$Program86\Microsoft Visual Studio\2026"
+			"$Program64\Microsoft Visual Studio\18"
+			"$Program86\Microsoft Visual Studio\18"
+		}
+		elseif ($Version -eq '17.0') {
+			"$Program64\Microsoft Visual Studio\2022"
+			"$Program86\Microsoft Visual Studio\2022"
+		}
+		elseif ($Version -eq '16.0') {
+			"$Program86\Microsoft Visual Studio\2019"
+		}
+		else {
+			"$Program86\Microsoft Visual Studio\2017"
+		}
+	)
+	foreach($folder in $folders) {
+		$items = @(Get-Item -ErrorAction 0 @(
+			"$folder\*\$(Get-MSBuild15Path Current $Bitness)"
+			"$folder\*\$(Get-MSBuild15Path $Version $Bitness)"
+		))
+		if ($items) {
+			break
+		}
+	}
+	if (!$items) {
+		if (!$Prerelease) {
+			Get-MSBuild15Guess $Version $Bitness -Latest:$Latest -Prerelease
+		}
+		return
+	}
+
+	if ($items.Count -ge 2) {
+		$byVersion = if ($Latest) {{[Version]$_.VersionInfo.FileVersion}} else {{([Version]$_.VersionInfo.FileVersion).Major}}
+		$byProduct = {
+			switch -Wildcard ($_.FullName) {
+				*\Enterprise\* {4}
+				*\Professional\* {3}
+				*\Community\* {2}
+				*\BuildTools\* {1}
+				default {0}
+			}
+		}
+		$items = $items | Sort-Object $byVersion, $byProduct
+	}
+
+	$items[-1].FullName
+}
+
+function Get-MSBuild15 {
+	[CmdletBinding()] param(
+		[string]$Version,
+		[string]$Bitness,
+		[switch]$Latest
+	)
+
+	if ($path = Get-MSBuild15VSSetup $Version $Bitness -Latest:$Latest) {
+		$path
+	}
+	else {
+		Get-MSBuild15Guess $Version $Bitness -Latest:$Latest
+	}
+}
+
+function Get-MSBuildOldVersion {
+	[CmdletBinding()] param(
+		[string]$Version,
+		[string]$Bitness
+	)
+
+	if ([System.IntPtr]::Size -eq 8 -and $Bitness -eq 'x86') {
+		$key = "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\MSBuild\ToolsVersions\$Version"
+	}
+	else {
+		$key = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$Version"
+	}
+	$rp = [Microsoft.Win32.Registry]::GetValue($key, 'MSBuildToolsPath', '')
+	if ($rp) {
+		Join-Path $rp MSBuild.exe
+	}
+}
+
+function Get-MSBuildOldLatest {
+	[CmdletBinding()] param(
+		[string]$Bitness
+	)
+
+	$rp = @(Get-ChildItem HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions | Sort-Object {[Version]$_.PSChildName})
+	if ($rp) {
+		Get-MSBuildOldVersion $rp[-1].PSChildName $Bitness
+	}
+}
+
+function Get-MSBuildAny {
+	[CmdletBinding()] param(
+		[string]$Bitness,
+		[switch]$Latest
+	)
+
+	if ($path = Get-MSBuild15 * $Bitness -Latest:$Latest) {
+		$path
+	}
+	else {
+		Get-MSBuildOldLatest $Bitness
+	}
+}
+
+$ErrorActionPreference=1
+
+if ($Version -match '^(.*?)x86\s*$') {
+	$Version = $Matches[1]
+	$Bitness = 'x86'
+}
+else {
+	$Bitness = ''
+}
+$Version = $Version.Trim()
+if (!$Version) {
+	$Version = '*'
+}
+
+$v18 = [Version]'18.0'
+$v17 = [Version]'17.0'
+$v16 = [Version]'16.0'
+$v15 = [Version]'15.0'
+$vMax = [Version]'9999.0'
+
+if ($Version -eq '*') {
+	$vRequired = $vMax
+}
+else {
+	try {
+		$vRequired = [Version]$Version
+	}
+	catch {
+		Write-Error "Invalid MSBuild version format: $Version."
+	}
+}
+
+$path = ''
+if ($vRequired -eq $v18 -or $vRequired -eq $v17 -or $vRequired -eq $v16 -or $vRequired -eq $v15) {
+	$path = Get-MSBuild15 $Version $Bitness -Latest:$Latest
+}
+elseif ($vRequired -lt $v15) {
+	$path = Get-MSBuildOldVersion $Version $Bitness
+}
+elseif ($vRequired -eq $vMax) {
+	$path = Get-MSBuildAny $Bitness -Latest:$Latest
+}
+
+if (!$path) {
+	Write-Error "Cannot find MSBuild version: $Version."
+}
+
+if ($MinimumVersion) {
+	$vResolved = [Version](& $path -version -nologo)
+	if ($vResolved -lt $MinimumVersion) {
+		Write-Error "MSBuild resolved version $vResolved is less than required minimum $MinimumVersion."
+	}
+}
+
+$path

--- a/Build/Modules/InvokeBuild/5.14.23/Show-TaskHelp.ps1
+++ b/Build/Modules/InvokeBuild/5.14.23/Show-TaskHelp.ps1
@@ -1,0 +1,277 @@
+<#
+.Synopsis
+	Shows Invoke-Build task help information.
+	Copyright (c) Roman Kuzmin
+
+.Description
+	The command shows the specified tasks help information as task names with
+	synopses, jobs with their locations, script parameters and environment. By
+	default, it analyses the code in order to extract variables in addition to
+	optionally documented in comments.
+
+	Synopsis is defined in task comments as # Synopsis: ...
+	Parameters are defined as # Parameters: name1, name2, ...
+	Environment variables are defined as # Environment: name1, name2, ...
+
+	Parameters names match build parameters and separated by spaces or commas.
+	Parameter descriptions are taken from the build script comment based help.
+
+	Help info members (for custom formatters):
+
+		Task: [object[]] Tasks to do.
+			Name: [string] Task name.
+			Synopsis: [string] Task synopsis, may be null.
+
+		Jobs: [object[]] Jobs to do.
+			Name: [string] Task name.
+			Location: [string] Task location as "<file>:<line>".
+
+		Parameters: [object[]] Tasks parameters, may be empty.
+			Name: [string] Parameter name.
+			Type: [string] Parameter type.
+			Description: [string] Parameter help, may be null or empty.
+
+		Environment: [string[]] Tasks environment variables, may be empty.
+
+.Parameter Task
+		Build task name(s). The default is the usual default task.
+
+.Parameter File
+		Build script path. The default is the usual default script.
+
+.Parameter NoCode
+		Tells to skip code analysis for parameters and environment.
+
+.Parameter Format
+		Specifies the custom task help formatter.
+
+.Link
+	https://github.com/nightroman/Invoke-Build
+#>
+
+param(
+	[Parameter(Position=0)]
+	[string[]]$Task
+	,
+	[Parameter(Position=1)]
+	[string]$File
+	,
+	[object]$Format = $(if ($Format = $PSCmdlet.GetVariableValue('Format')) {$Format} else {'Format-TaskHelp'})
+	,
+	[switch]$NoCode = $PSCmdlet.GetVariableValue('NoCode')
+)
+
+$ErrorActionPreference=1; trap {$PSCmdlet.ThrowTerminatingError($_)}
+
+# recall by IB
+if ([System.IO.Path]::GetFileName($MyInvocation.ScriptName) -ne 'Invoke-Build.ps1') {
+	Invoke-Build $Task $File -WhatIf
+	return
+}
+
+$All = ${*}.All
+$BB = ${*}.BB
+$DP = ${*}.DP
+Remove-Variable Task
+
+### script parameters help
+
+function get_help($File) {
+	Set-StrictMode -Off
+	@(if ($r = Get-Help $File) {if ($r = $r.parameters) {if ($r = $r.parameter) {$r}}})
+}
+
+$Help = @(
+	foreach($b in $BB) {
+		get_help $b.FS
+	}
+)
+
+$Hash = @{}
+$BuildJobs = @()
+$MapParameter = @{}
+$MapEnvironment = @{}
+
+# collect jobs in $BuildJobs
+function Add-TaskJob($Jobs, $Task) {
+	foreach($job in $Jobs) {
+		if ($job -is [string]) {
+			$task2 = $All[$job.TrimStart('?')]
+			Add-TaskJob $task2.Jobs $task2
+		}
+		else {
+			if ($BuildJobs -notcontains $Task.Name) {
+				$script:BuildJobs += $Task.Name
+			}
+		}
+	}
+
+	if ($Task -and $Task.If -is [scriptblock]) {
+		if ($BuildJobs -notcontains $Task.Name) {
+			$script:BuildJobs += $Task.Name
+		}
+	}
+}
+
+# get parameters and environment from comments
+function Get-TaskComment($Task) {
+	$f = ($I = $Task.InvocationInfo).ScriptName
+	if (!($d = $Hash[$f])) {
+		$Hash[$f] = $d = @{T = Get-Content -LiteralPath $f; C = @{}}
+		foreach($_ in [System.Management.Automation.PSParser]::Tokenize($d.T, [ref]$null)) {
+			if ($_.Type -eq 15) {$d.C[$_.EndLine] = $_.Content}
+		}
+	}
+	$r = @{Parameters = @(); Environment = @()}
+	for($n = $I.ScriptLineNumber; --$n -ge 1) {
+		if ($c = $d.C[$n]) {
+			if ($c -match '(?m)^\s*#*\s*Parameters\s*:(.*)') {$r.Parameters = $Matches[1].Trim() -split '[\s,]+'}
+			elseif ($c -match '(?m)^\s*#*\s*Environment\s*:(.*)') {$r.Environment = $Matches[1].Trim() -split '[\s,]+'}
+		}
+		elseif ($d.T[$n - 1].Trim()) {
+			break
+		}
+	}
+	$r
+}
+
+function Add-VariablePath($Path) {
+	$index = $Path.IndexOf(':')
+	if ($index -ge 0) {
+		$prefix = $Path.Substring(0, $index)
+		$name = $Path.Substring($index + 1)
+	}
+	else {
+		$prefix = ''
+		$name = $Path
+	}
+	if (!$prefix -or $prefix -eq 'script') {
+		if ($DP.ContainsKey($name)) {
+			$MapParameter[$name] = 1
+		}
+	}
+	elseif ($prefix -eq 'env') {
+		$MapEnvironment[$name] = 1
+	}
+}
+
+function Add-BlockVariable($Block) {
+	foreach($variable in $Block.Ast.FindAll({$args[0] -is [System.Management.Automation.Language.VariableExpressionAst]}, $true)) {
+		if ($variable.Parent -isnot [System.Management.Automation.Language.AssignmentStatementAst]) {
+			Add-VariablePath $variable.VariablePath.UserPath
+		}
+	}
+}
+
+function Add-TaskVariable($Jobs) {
+	foreach($job in $Jobs) {
+		$task = $All[$job]
+		$info = Get-TaskComment $task
+
+		foreach($name in $info.Environment) {
+			$MapEnvironment[$name] = 1
+		}
+		foreach($name in $info.Parameters) {
+			if ($DP.ContainsKey($name)) {
+				$MapParameter[$name] = 1
+			}
+			else {
+				Write-Warning "Task '$($task.Name)': unknown parameter '$name'."
+			}
+		}
+
+		if (!$NoCode) {
+			foreach($job in @($Task.If; $Task.Inputs; $Task.Outputs; $task.Jobs)) {
+				if ($job -is [scriptblock]) {
+					Add-BlockVariable $job
+				}
+			}
+		}
+	}
+}
+
+function Format-TaskHelp($TaskHelp) {
+	print White Task:
+	foreach($r in $TaskHelp.Task) {
+		if ($synopsis = $r.Synopsis) {
+			print Gray ('    {0} - {1}' -f $r.Name, $synopsis)
+		}
+		else {
+			print Gray ('    {0}' -f $r.Name)
+		}
+	}
+
+	print White Jobs:
+	foreach($r in $TaskHelp.Jobs) {
+		if ($synopsis = Get-BuildSynopsis ($All[$r.Name]) $Hash) {
+			print Gray ('    {0} - {1} At {2}' -f $r.Name, $synopsis, $r.Location)
+		}
+		else {
+			print Gray ('    {0} - At {1}' -f $r.Name, $r.Location)
+		}
+	}
+
+	if ($TaskHelp.Parameters) {
+		print White Parameters:
+		foreach($p in $TaskHelp.Parameters) {
+			print Gray ('    [{0}] {1}' -f $p.Type, $p.Name)
+			if ($p.Description) {
+				print Gray ('        {0}' -f $p.Description)
+			}
+		}
+	}
+
+	if ($TaskHelp.Environment) {
+		print White Environment:
+		print Gray ('    {0}' -f ($TaskHelp.Environment -join ', '))
+	}
+}
+
+### .Task
+$TaskHelp = [pscustomobject]@{Task=$null; Jobs=$null; Synopsis=$null; Location=$null; Parameters=$null; Environment=$null}
+$TaskHelp.Task = @(
+	foreach($job in $BuildTask) {
+		$task = $All[$job.TrimStart('?')]
+		[pscustomobject]@{
+			Name = $task.Name
+			Synopsis = Get-BuildSynopsis $task $Hash
+		}
+	}
+)
+
+### .Jobs
+Add-TaskJob $BuildTask
+$TaskHelp.Jobs = @(
+	foreach($name in $BuildJobs) {
+		$task = $All[$name]
+		[pscustomobject]@{
+			Name = $task.Name
+			Location = '{0}:{1}' -f $task.InvocationInfo.ScriptName, $task.InvocationInfo.ScriptLineNumber
+		}
+	}
+)
+
+### .Parameters and .Environment
+Add-TaskVariable $BuildJobs
+$TaskHelp.Environment = @($MapEnvironment.get_Keys() | Sort-Object)
+
+# make parameter objects with help
+$TaskHelp.Parameters = @()
+foreach($name in $MapParameter.get_Keys()) {
+	$p = $DP[$name]
+	$r = [pscustomobject]@{
+		Name = $name
+		Type = $(if (($type = $p.ParameterType.Name) -eq 'SwitchParameter') {'switch'} else {$type})
+		Description = foreach($_ in $Help) {
+			if ($_.name -eq $name -and $_.PSObject.Properties['description']) {
+				($_.description | Out-String).Trim()
+				break
+			}
+		}
+	}
+	$TaskHelp.Parameters += $r
+}
+$TaskHelp.Parameters = @($TaskHelp.Parameters | Sort-Object {$_.Type -eq 'switch'}, Name)
+
+### format
+& $Format $TaskHelp

--- a/Build/Modules/InvokeBuild/5.14.23/about_InvokeBuild.help.txt
+++ b/Build/Modules/InvokeBuild/5.14.23/about_InvokeBuild.help.txt
@@ -1,0 +1,54 @@
+TOPIC
+    about_InvokeBuild
+
+SHORT DESCRIPTION
+    Build and test automation in PowerShell
+
+LONG DESCRIPTION
+    The module provides the following commands:
+
+        Invoke-Build
+            The alias of Invoke-Build.ps1
+            It invokes build scripts, this is the build engine.
+
+        Build-Checkpoint
+            The alias of Build-Checkpoint.ps1
+            It invokes persistent builds using the engine.
+
+        Build-Parallel
+            The alias of Build-Parallel.ps1
+            It invokes parallel builds using the engine.
+
+    Import the installed module:
+
+        Import-Module InvokeBuild
+        $ModuleBase = (Get-Module InvokeBuild).ModuleBase # for help
+
+    Or import from the specified location:
+
+        $ModuleBase = <folder with Invoke-Build.ps1> # for import and help
+        Import-Module $ModuleBase
+
+    Get help for Invoke-Build and see available build commands:
+
+        help $ModuleBase\Invoke-Build.ps1 -full
+
+    Get help for build commands:
+
+        . $ModuleBase\Invoke-Build.ps1
+        help task -full
+        help exec -full
+        ...
+
+HELPER SCRIPTS
+
+    The helper scripts Resolve-MSBuild.ps1 and Show-TaskHelp.ps1 are included
+    to the package but not exposed as aliases. Call them directly. Either add
+    the folder to the path or use the folder path $ModuleBase, see above.
+
+MORE HELPERS
+
+    The repository provides more helper scripts and tools, see README.
+    On Windows you can open README.html from the package like this:
+
+        Invoke-Item $ModuleBase\README.html


### PR DESCRIPTION
This pull request updates how the `InvokeBuild` PowerShell module is used and introduces a vendored version (`5.14.23`) of the module directly into the repository. The build process for the VS Code extension is updated to use this local module instead of installing it from the PowerShell Gallery. Documentation and CI workflows are also updated to reflect this change.

Vendoring of InvokeBuild module:

* Added the entire `InvokeBuild` PowerShell module version `5.14.23` under `Build/Modules/InvokeBuild/5.14.23`, including scripts (`Build-Checkpoint.ps1`, `Build-Parallel.ps1`), module manifest (`InvokeBuild.psd1`), module entry point (`InvokeBuild.psm1`), and license. [[1]](diffhunk://#diff-177a4d9ef6dee60ed8b0c92b71c726b8c52f7c97749f6373f3e0fe9406265ea9R1-R148) [[2]](diffhunk://#diff-9cc962ff48cbc4400ee2becba70234508049e2e476be82c89699a3768a442235R1-R270) [[3]](diffhunk://#diff-af6af1a578ea18a9215a7e96a37fc28b23c983c9b8b69663089b613633ee7055R1-R23) [[4]](diffhunk://#diff-dfc510f1d088b013428b508637e3cde2d518a97288ab7545d393be0901b9b1adR1-R5) [[5]](diffhunk://#diff-e277b469046a491579882694b20e746d8c059f1d99341e2589703d060d87bb15R1-R178)

Build and workflow changes:

* Updated `.github/workflows/vscode.ci.yml` and `.github/workflows/vscode.production.yml` to import the vendored `InvokeBuild` module instead of installing it from the PowerShell Gallery. [[1]](diffhunk://#diff-d45da97e9b8773127678f896c8c381b4884fc1ebe22bbb82d6265e7e5e6dade7L54-R54) [[2]](diffhunk://#diff-2d3a11ca99cd4edb01f93cc5581587535b643afe472436db7504d5744d3aa71fL49-R49)
* Updated `AGENTS.md` documentation to instruct contributors to use the vendored module for local builds.

These changes ensure consistent build tooling across all environments and eliminate the dependency on external sources for the `InvokeBuild` module.