### PR TITLE
Fix VS Code rename for single-file windows

### DIFF
--- a/HostInjection/PoshToolsServer.cs
+++ b/HostInjection/PoshToolsServer.cs
@@ -948,6 +948,11 @@ $RS.Events.SubscribeEvent($null, 'PowerShell.OnIdle',  'PowerShell.OnIdle', $nul
             var renameSymbol = new RenameSymbol();
 
             var workspace = _workspaceAnalysisService.GetWorkspace(workspaceRoot);
+            if (workspace == null && Directory.Exists(workspaceRoot))
+            {
+                workspace = _workspaceAnalysisService.AddWorkspace(workspaceRoot);
+            }
+
             if (workspace == null)
             {
                 return new TextEdit[0];

--- a/HostInjection/WorkspaceAnalysisService.cs
+++ b/HostInjection/WorkspaceAnalysisService.cs
@@ -175,11 +175,19 @@ namespace PowerShellProTools.Host
             return workspace.FunctionDefinitions.Where(m => m.FileName.Equals(file, StringComparison.OrdinalIgnoreCase));
         }
 
-        public void AddWorkspace(string root)
+        public Workspace AddWorkspace(string root)
         {
-            var workspace = new Workspace(root);
+            var workspace = GetWorkspace(root);
+            if (workspace != null)
+            {
+                return workspace;
+            }
+
+            workspace = new Workspace(root);
             workspaces.Add(workspace);
             AnalyzeWorkspace(root);
+
+            return workspace;
         }
 
         public void AnalyzeFile(string file)

--- a/vscode/powershellprotools/src/services/renameProvider.ts
+++ b/vscode/powershellprotools/src/services/renameProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import path = require("path");
 import { Container } from '../container';
 import { RefactorRequest, TextEditorState, TextEditType } from '../types';
 
@@ -11,8 +12,9 @@ export class PowerShellRenameProvider implements vscode.RenameProvider {
         const request = this.createRefactorRequest(position, document);
 
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+        const workspaceRoot = workspaceFolder ? workspaceFolder.uri.fsPath : path.dirname(document.uri.fsPath);
 
-        var result = await Container.PowerShellService.RenameSymbol(newName, workspaceFolder.uri.fsPath, request);
+        var result = await Container.PowerShellService.RenameSymbol(newName, workspaceRoot, request);
 
         let we = new vscode.WorkspaceEdit();
 


### PR DESCRIPTION
VS Code can run the extension with a single PowerShell file open and no workspace folder. Rename symbol previously assumed every document belonged to a workspace, so it failed before the host could process the rename.

This change falls back to the opened file's directory as the workspace root and has the host analyze that root on demand when rename is invoked. Existing folder-based workspaces continue to use the VS Code workspace folder path.

Fixes #154