### PR TITLE
Publish VS Code extension to Open VSX

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,6 +108,15 @@ jobs:
       env:
         VSCE: ${{ secrets.VSCODE_MARKETPLACE_KEY }}
 
+    - name: Publish VS Code extension to Open VSX
+      shell: pwsh
+      run: |
+        Set-Location .\vscode\powershellprotools
+        $Version = (ConvertFrom-Json (Get-Content -Raw .\package.json)).Version
+        npx --yes ovsx publish ".\kit\powershellprotools-$($Version).vsix"
+      env:
+        OVSX_PAT: ${{ secrets.OVSX_PAT }}
+
     - name: Publish Windows Form Designer
       shell: pwsh
       run: |

--- a/vscode/powershellprotools/package.json
+++ b/vscode/powershellprotools/package.json
@@ -4,6 +4,7 @@
     "description": "Powerful extensions for PowerShell development.",
     "version": "2025.11.0",
     "publisher": "ironmansoftware",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "https://github.com/ironmansoftware/powershell-pro-tools"


### PR DESCRIPTION
Adds an Open VSX publish step to the release workflow using the existing VSIX package and OVSX_PAT secret.

Declares the VS Code extension MIT license in package.json so Open VSX metadata validation can pass.

Fixes  https://github.com/ironmansoftware/powershell-pro-tools/issues/139