### PR TITLE
Reduce packager AV false positive triggers

### DIFF
--- a/PowerShellToolsPro.Packager.Test/ConfigDeserializerTests.cs
+++ b/PowerShellToolsPro.Packager.Test/ConfigDeserializerTests.cs
@@ -23,6 +23,24 @@ namespace PowerShellToolsPro.Packager.Test
 
             Assert.Equal(2, config.Bundle.IgnoredModules.Length);
         }
+
+        [Fact]
+        public void ShouldDeserializeTimestampServer()
+        {
+            var pathResolverMock = NSubstitute.Substitute.For<IPathResolver>();
+
+            var deserializer = new ConfigDeserializer(pathResolverMock);
+
+            var hashtable = new Hashtable();
+            var package = new Hashtable();
+            hashtable.Add("Package", package);
+
+            package.Add("TimestampServer", "http://timestamp.digicert.com");
+
+            var config = deserializer.Deserialize(hashtable);
+
+            Assert.Equal("http://timestamp.digicert.com", config.Package.TimestampServer);
+        }
     }
 
 

--- a/PowerShellToolsPro.Packager/Compiler.cs
+++ b/PowerShellToolsPro.Packager/Compiler.cs
@@ -182,7 +182,7 @@ namespace PowerShellToolsPro.Packager
             if (!string.IsNullOrEmpty(config.Certificate))
             {
                 OnBuildOutput($"Signing assembly with certificate {config.Certificate}");
-                SignAssembly(config.Certificate, resultingAssembly);
+                SignAssembly(config.Certificate, config.TimestampServer, resultingAssembly);
             }
 
             return resultingAssembly;
@@ -193,7 +193,7 @@ namespace PowerShellToolsPro.Packager
             return str.Replace("'", "%27");
         }
 
-        private void SignAssembly(string certificate, string path)
+        private void SignAssembly(string certificate, string timestampServer, string path)
         {
             X509Certificate2 cert = null;
             using (var ps = PowerShell.Create())
@@ -208,9 +208,14 @@ namespace PowerShellToolsPro.Packager
 
             using (var ps = PowerShell.Create())
             {
-                ps.AddCommand("Set-AuthenticodeSignature")
+                var command = ps.AddCommand("Set-AuthenticodeSignature")
                     .AddParameter("FilePath", path)
                     .AddParameter("Certificate", cert);
+                if (!string.IsNullOrEmpty(timestampServer))
+                {
+                    command.AddParameter("TimestampServer", timestampServer);
+                }
+
                 var result = ps.Invoke().First();
 
                 if (ps.HadErrors)

--- a/PowerShellToolsPro.Packager/Config/ConfigDeserializer.cs
+++ b/PowerShellToolsPro.Packager/Config/ConfigDeserializer.cs
@@ -55,6 +55,7 @@ namespace PowerShellToolsPro.Packager.Config
                 config.Package.Resources = ReadScalarValue<string[]>(packagerHashtable, "Resources");
                 config.Package.DotNetSdk = ReadScalarValue<string>(packagerHashtable, "DotNetSdk");
                 config.Package.Certificate = ReadScalarValue<string>(packagerHashtable, "Certificate");
+                config.Package.TimestampServer = ReadScalarValue<string>(packagerHashtable, "TimestampServer");
                 config.Package.OutputName = ReadScalarValue<string>(packagerHashtable, "OutputName");
                 config.Package.Lightweight = ReadScalarValue<bool>(packagerHashtable, "Lightweight");
             }

--- a/PowerShellToolsPro.Packager/Config/PackageConfig.cs
+++ b/PowerShellToolsPro.Packager/Config/PackageConfig.cs
@@ -40,6 +40,7 @@
         public string[] Resources { get; set; } = new string[0];
         public string DotNetSdk { get; set; }
         public string Certificate { get; set; }
+        public string TimestampServer { get; set; }
         public string OutputName { get; set; }
         public PowerShellHosts Host { get; set; }
         public bool Lightweight { get; set; }

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost.cs
@@ -123,15 +123,20 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         private static void DeleteModuleDirectory(string directory)
         {
-            if (Directory.Exists(directory))
+            if (!Directory.Exists(directory))
             {
-                var powershell = new Process();
-                powershell.StartInfo = new ProcessStartInfo();
-                powershell.StartInfo.UseShellExecute = false;
-                powershell.StartInfo.CreateNoWindow = true;
-                powershell.StartInfo.FileName = "powershell";
-                powershell.StartInfo.Arguments = $"-WindowStyle Hidden -NoProfile -NonInteractive -Command \"Start-Sleep 2; Remove-Item '{directory}' -Force -Recurse\"";
-                powershell.Start();
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(directory, true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
             }
         }
 

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost.cs
@@ -16,8 +16,16 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 {
 	class Program
 	{
+        private const string CleanupArgument = "--poshtools-cleanup";
+
         static int Main(string[] args)
         {
+            if (args.Length == 2 && args[0] == CleanupArgument)
+            {
+                DeleteModuleDirectory(args[1]);
+                return 0;
+            }
+
             // License
 
             var arguments = new List<string>();
@@ -75,7 +83,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             finally
             {
                 if (!string.IsNullOrEmpty(modulePath))
-                    DeleteModuleDirectory(modulePath);
+                    ScheduleModuleDirectoryCleanup(modulePath);
             }
         }
 
@@ -121,23 +129,50 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             Environment.SetEnvironmentVariable("PSModulePath", pathvar);
         }
 
-        private static void DeleteModuleDirectory(string directory)
+        private static void ScheduleModuleDirectoryCleanup(string directory)
         {
             if (!Directory.Exists(directory))
             {
                 return;
             }
 
-            try
+            var cleanup = new Process();
+            cleanup.StartInfo = new ProcessStartInfo();
+            cleanup.StartInfo.UseShellExecute = false;
+            cleanup.StartInfo.CreateNoWindow = true;
+            cleanup.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+            cleanup.StartInfo.Arguments = CleanupArgument + " " + QuoteArgument(directory);
+            cleanup.Start();
+        }
+
+        private static void DeleteModuleDirectory(string directory)
+        {
+            for (var retry = 0; retry < 30; retry++)
             {
-                Directory.Delete(directory, true);
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                try
+                {
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(1000);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(1000);
+                }
             }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
+        }
+
+        private static string QuoteArgument(string argument)
+        {
+            return "\"" + argument.Replace("\"", "\\\"") + "\"";
         }
 
         public static string AssemblyDirectory

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Core.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Core.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Text;
 using System.IO.Compression;
 using System.Diagnostics;
+using System.Threading;
 using System.Security.Cryptography;
 
 #pragma warning disable SYSLIB0021, SYSLIB0012
@@ -17,6 +18,8 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 {
     class Program
     {
+        private const string CleanupArgument = "--poshtools-cleanup";
+
         [DllImport("Kernel32.dll")]
         public static extern bool AllocConsole();
         [DllImport("user32.dll")]
@@ -28,6 +31,12 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         static int Main(string[] args)
         {
+            if (args.Length == 2 && args[0] == CleanupArgument)
+            {
+                DeleteModuleDirectory(args[1]);
+                return 0;
+            }
+
             // License
 
             var arguments = new List<string>();
@@ -84,7 +93,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             }
             finally
             {
-                DeleteModuleDirectory(modulePath);
+                ScheduleModuleDirectoryCleanup(modulePath);
             }
         }
 
@@ -139,23 +148,50 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             Environment.SetEnvironmentVariable("PSModulePath", path);
         }
 
-        private static void DeleteModuleDirectory(string directory)
+        private static void ScheduleModuleDirectoryCleanup(string directory)
         {
             if (!Directory.Exists(directory))
             {
                 return;
             }
 
-            try
+            var cleanup = new Process();
+            cleanup.StartInfo = new ProcessStartInfo();
+            cleanup.StartInfo.UseShellExecute = false;
+            cleanup.StartInfo.CreateNoWindow = true;
+            cleanup.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+            cleanup.StartInfo.Arguments = CleanupArgument + " " + QuoteArgument(directory);
+            cleanup.Start();
+        }
+
+        private static void DeleteModuleDirectory(string directory)
+        {
+            for (var retry = 0; retry < 30; retry++)
             {
-                Directory.Delete(directory, true);
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                try
+                {
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(1000);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(1000);
+                }
             }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
+        }
+
+        private static string QuoteArgument(string argument)
+        {
+            return "\"" + argument.Replace("\"", "\\\"") + "\"";
         }
 
         public static string AssemblyDirectory

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Core.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Core.cs
@@ -77,7 +77,6 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
                 var myArgs = new List<string>();
                 //Arguments
-                myArgs.AddRange(new[] { "-ExecutionPolicy", "Unrestricted" }); //, "-Command", $"& {{ {contents.TrimEnd('\r', '\n')} }}" });
                 myArgs.AddRange(new[] { "-Command", contents.TrimEnd('\r', '\n') });
                 myArgs.AddRange(arguments);
                 myArgs.AddRange(new[] { "-PoshToolsRoot", "\"" + AssemblyDirectory + "\"" });
@@ -142,20 +141,21 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         private static void DeleteModuleDirectory(string directory)
         {
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
             try
             {
-                if (Directory.Exists(directory))
-                {
-                    var powershell = new Process();
-                    powershell.StartInfo = new ProcessStartInfo();
-                    powershell.StartInfo.CreateNoWindow = true;
-                    powershell.StartInfo.FileName = "powershell";
-                    powershell.StartInfo.Arguments = $"-NoProfile -NonInteractive -Command \"Start-Sleep 2; Remove-Item '{directory}' -Force -Recurse\"";
-                    powershell.Start();
-                }
+                Directory.Delete(directory, true);
             }
-            catch { }
-
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
         }
 
         public static string AssemblyDirectory

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Hidden.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Hidden.cs
@@ -16,6 +16,8 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 {
     class Program
     {
+        private const string CleanupArgument = "--poshtools-cleanup";
+
         [DllImport("user32.dll")]
         public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
         [DllImport("kernel32")]
@@ -33,6 +35,12 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         static int Main(string[] args)
         {
+            if (args.Length == 2 && args[0] == CleanupArgument)
+            {
+                DeleteModuleDirectory(args[1]);
+                return 0;
+            }
+
             // License
 
             var arguments = new List<string>();
@@ -91,7 +99,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             finally
             {
                 _console?.Kill();
-                DeleteModuleDirectory(modulePath);
+                ScheduleModuleDirectoryCleanup(modulePath);
             }
         }
 
@@ -137,23 +145,50 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             Environment.SetEnvironmentVariable("PSModulePath", pathvar);
         }
 
-        private static void DeleteModuleDirectory(string directory)
+        private static void ScheduleModuleDirectoryCleanup(string directory)
         {
             if (!Directory.Exists(directory))
             {
                 return;
             }
 
-            try
+            var cleanup = new Process();
+            cleanup.StartInfo = new ProcessStartInfo();
+            cleanup.StartInfo.UseShellExecute = false;
+            cleanup.StartInfo.CreateNoWindow = true;
+            cleanup.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+            cleanup.StartInfo.Arguments = CleanupArgument + " " + QuoteArgument(directory);
+            cleanup.Start();
+        }
+
+        private static void DeleteModuleDirectory(string directory)
+        {
+            for (var retry = 0; retry < 30; retry++)
             {
-                Directory.Delete(directory, true);
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                try
+                {
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(1000);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(1000);
+                }
             }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
+        }
+
+        private static string QuoteArgument(string argument)
+        {
+            return "\"" + argument.Replace("\"", "\\\"") + "\"";
         }
 
         public static string AssemblyDirectory

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Hidden.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Hidden.cs
@@ -139,15 +139,20 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         private static void DeleteModuleDirectory(string directory)
         {
-            if (Directory.Exists(directory))
+            if (!Directory.Exists(directory))
             {
-                var powershell = new Process();
-                powershell.StartInfo = new ProcessStartInfo();
-                powershell.StartInfo.UseShellExecute = false;
-                powershell.StartInfo.CreateNoWindow = true;
-                powershell.StartInfo.FileName = "powershell";
-                powershell.StartInfo.Arguments = $"-WindowStyle Hidden -NoProfile -NonInteractive -Command \"Start-Sleep 2; Remove-Item '{directory}' -Force -Recurse\"";
-                powershell.Start();
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(directory, true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
             }
         }
 

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Linux.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Linux.cs
@@ -61,7 +61,6 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
                 var myArgs = new List<string>();
                 //Arguments
-                myArgs.AddRange(new[] { "-ExecutionPolicy", "Unrestricted" }); //, "-Command", $"& {{ {contents.TrimEnd('\r', '\n')} }}" });
                 myArgs.AddRange(new[] { "-Command", contents.TrimEnd('\r', '\n') });
                 myArgs.AddRange(arguments);
                 myArgs.AddRange(new[] { "-PoshToolsRoot", "\"" + AssemblyDirectory + "\"" });
@@ -115,20 +114,21 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         private static void DeleteModuleDirectory(string directory)
         {
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
             try
             {
-                if (Directory.Exists(directory))
-                {
-                    var powershell = new Process();
-                    powershell.StartInfo = new ProcessStartInfo();
-                    powershell.StartInfo.CreateNoWindow = true;
-                    powershell.StartInfo.FileName = "pwsh";
-                    powershell.StartInfo.Arguments = $"-NoProfile -NonInteractive -Command \"Start-Sleep 2; Remove-Item '{directory}' -Force -Recurse\"";
-                    powershell.Start();
-                }
+                Directory.Delete(directory, true);
             }
-            catch { }
-
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
         }
 
         public static string AssemblyDirectory

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Linux.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Linux.cs
@@ -9,14 +9,23 @@ using System.ComponentModel;
 using System.Text;
 using System.IO.Compression;
 using System.Diagnostics;
+using System.Threading;
 using System.Security.Cryptography;
 
 namespace PowerShellToolsPro.Packager.ConsoleHost
 {
     class Program
     {
+        private const string CleanupArgument = "--poshtools-cleanup";
+
         static int Main(string[] args)
         {
+            if (args.Length == 2 && args[0] == CleanupArgument)
+            {
+                DeleteModuleDirectory(args[1]);
+                return 0;
+            }
+
             // License
 
             var arguments = new List<string>();
@@ -68,7 +77,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             }
             finally
             {
-                DeleteModuleDirectory(modulePath);
+                ScheduleModuleDirectoryCleanup(modulePath);
             }
         }
 
@@ -112,23 +121,50 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             Environment.SetEnvironmentVariable("PSModulePath", path);
         }
 
-        private static void DeleteModuleDirectory(string directory)
+        private static void ScheduleModuleDirectoryCleanup(string directory)
         {
             if (!Directory.Exists(directory))
             {
                 return;
             }
 
-            try
+            var cleanup = new Process();
+            cleanup.StartInfo = new ProcessStartInfo();
+            cleanup.StartInfo.UseShellExecute = false;
+            cleanup.StartInfo.CreateNoWindow = true;
+            cleanup.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+            cleanup.StartInfo.Arguments = CleanupArgument + " " + QuoteArgument(directory);
+            cleanup.Start();
+        }
+
+        private static void DeleteModuleDirectory(string directory)
+        {
+            for (var retry = 0; retry < 30; retry++)
             {
-                Directory.Delete(directory, true);
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                try
+                {
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(1000);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(1000);
+                }
             }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
+        }
+
+        private static string QuoteArgument(string argument)
+        {
+            return "\"" + argument.Replace("\"", "\\\"") + "\"";
         }
 
         public static string AssemblyDirectory

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Osx.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Osx.cs
@@ -61,7 +61,6 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
                 var myArgs = new List<string>();
                 //Arguments
-                myArgs.AddRange(new[] { "-ExecutionPolicy", "Unrestricted" }); //, "-Command", $"& {{ {contents.TrimEnd('\r', '\n')} }}" });
                 myArgs.AddRange(new[] { "-Command", contents.TrimEnd('\r', '\n') });
                 myArgs.AddRange(arguments);
                 myArgs.AddRange(new[] { "-PoshToolsRoot", "\"" + AssemblyDirectory + "\"" });
@@ -115,20 +114,21 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         private static void DeleteModuleDirectory(string directory)
         {
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
             try
             {
-                if (Directory.Exists(directory))
-                {
-                    var powershell = new Process();
-                    powershell.StartInfo = new ProcessStartInfo();
-                    powershell.StartInfo.CreateNoWindow = true;
-                    powershell.StartInfo.FileName = "pwsh";
-                    powershell.StartInfo.Arguments = $"-NoProfile -NonInteractive -Command \"Start-Sleep 2; Remove-Item '{directory}' -Force -Recurse\"";
-                    powershell.Start();
-                }
+                Directory.Delete(directory, true);
             }
-            catch { }
-
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
         }
 
         public static string AssemblyDirectory

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Osx.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Osx.cs
@@ -9,14 +9,23 @@ using System.ComponentModel;
 using System.Text;
 using System.IO.Compression;
 using System.Diagnostics;
+using System.Threading;
 using System.Security.Cryptography;
 
 namespace PowerShellToolsPro.Packager.ConsoleHost
 {
     class Program
     {
+        private const string CleanupArgument = "--poshtools-cleanup";
+
         static int Main(string[] args)
         {
+            if (args.Length == 2 && args[0] == CleanupArgument)
+            {
+                DeleteModuleDirectory(args[1]);
+                return 0;
+            }
+
             // License
 
             var arguments = new List<string>();
@@ -68,7 +77,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             }
             finally
             {
-                DeleteModuleDirectory(modulePath);
+                ScheduleModuleDirectoryCleanup(modulePath);
             }
         }
 
@@ -112,23 +121,50 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             Environment.SetEnvironmentVariable("PSModulePath", path);
         }
 
-        private static void DeleteModuleDirectory(string directory)
+        private static void ScheduleModuleDirectoryCleanup(string directory)
         {
             if (!Directory.Exists(directory))
             {
                 return;
             }
 
-            try
+            var cleanup = new Process();
+            cleanup.StartInfo = new ProcessStartInfo();
+            cleanup.StartInfo.UseShellExecute = false;
+            cleanup.StartInfo.CreateNoWindow = true;
+            cleanup.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+            cleanup.StartInfo.Arguments = CleanupArgument + " " + QuoteArgument(directory);
+            cleanup.Start();
+        }
+
+        private static void DeleteModuleDirectory(string directory)
+        {
+            for (var retry = 0; retry < 30; retry++)
             {
-                Directory.Delete(directory, true);
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                try
+                {
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(1000);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(1000);
+                }
             }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
+        }
+
+        private static string QuoteArgument(string argument)
+        {
+            return "\"" + argument.Replace("\"", "\\\"") + "\"";
         }
 
         public static string AssemblyDirectory

--- a/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost.cs
@@ -138,11 +138,21 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         private static void DeleteModuleDirectory(string directory)
         {
-            var powershell = new Process();
-            powershell.StartInfo = new ProcessStartInfo();
-            powershell.StartInfo.FileName = "powershell";
-            powershell.StartInfo.Arguments = $"-WindowStyle Hidden -NoProfile -NonInteractive -Command \"Start-Sleep 2; Remove-Item '{directory}' -Force -Recurse\"";
-            powershell.Start();
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(directory, true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
         }
 
         public static string ReplaceString(string str, string oldValue, string newValue, StringComparison comparison)

--- a/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.IO.Compression;
 using System.ServiceProcess;
 using System.Diagnostics;
+using System.Threading;
 using System.Security.Cryptography;
 using System.Configuration.Install;
 
@@ -19,8 +20,16 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 {
 	class Program
 	{
+        private const string CleanupArgument = "--poshtools-cleanup";
+
         static void Main(string[] args)
 		{
+            if (args.Length == 2 && args[0] == CleanupArgument)
+            {
+                DeleteModuleDirectory(args[1]);
+                return;
+            }
+
             string modulePath = string.Empty;
             try
             {
@@ -90,7 +99,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             finally
             {
                 if (!string.IsNullOrEmpty(modulePath))
-                    DeleteModuleDirectory(modulePath);
+                    ScheduleModuleDirectoryCleanup(modulePath);
             }
         }
 
@@ -136,23 +145,50 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             Environment.SetEnvironmentVariable("PSModulePath", pathvar);
         }
 
-        private static void DeleteModuleDirectory(string directory)
+        private static void ScheduleModuleDirectoryCleanup(string directory)
         {
             if (!Directory.Exists(directory))
             {
                 return;
             }
 
-            try
+            var cleanup = new Process();
+            cleanup.StartInfo = new ProcessStartInfo();
+            cleanup.StartInfo.UseShellExecute = false;
+            cleanup.StartInfo.CreateNoWindow = true;
+            cleanup.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+            cleanup.StartInfo.Arguments = CleanupArgument + " " + QuoteArgument(directory);
+            cleanup.Start();
+        }
+
+        private static void DeleteModuleDirectory(string directory)
+        {
+            for (var retry = 0; retry < 30; retry++)
             {
-                Directory.Delete(directory, true);
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                try
+                {
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(1000);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(1000);
+                }
             }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
+        }
+
+        private static string QuoteArgument(string argument)
+        {
+            return "\"" + argument.Replace("\"", "\\\"") + "\"";
         }
 
         public static string ReplaceString(string str, string oldValue, string newValue, StringComparison comparison)

--- a/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost_Core.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost_Core.cs
@@ -122,11 +122,21 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 
         private static void DeleteModuleDirectory(string directory)
         {
-            var powershell = new Process();
-            powershell.StartInfo = new ProcessStartInfo();
-            powershell.StartInfo.FileName = "powershell";
-            powershell.StartInfo.Arguments = $"-WindowStyle Hidden -NoProfile -NonInteractive -Command \"Start-Sleep 2; Remove-Item '{directory}' -Force -Recurse\"";
-            powershell.Start();
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(directory, true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
         }
 
         public static string ReplaceString(string str, string oldValue, string newValue, StringComparison comparison)

--- a/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost_Core.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost_Core.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.IO.Compression;
 using System.ServiceProcess;
 using System.Diagnostics;
+using System.Threading;
 using System.Security.Cryptography;
 
 
@@ -18,8 +19,16 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
 {
 	class Program
 	{
+        private const string CleanupArgument = "--poshtools-cleanup";
+
         static void Main(string[] args)
 		{
+            if (args.Length == 2 && args[0] == CleanupArgument)
+            {
+                DeleteModuleDirectory(args[1]);
+                return;
+            }
+
             string modulePath = string.Empty;
             try
             {
@@ -73,7 +82,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             finally
             {
                 if (!string.IsNullOrEmpty(modulePath))
-                    DeleteModuleDirectory(modulePath);
+                    ScheduleModuleDirectoryCleanup(modulePath);
             }
         }
 
@@ -120,23 +129,50 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
             Environment.SetEnvironmentVariable("PSModulePath", pathvar);
         }
 
-        private static void DeleteModuleDirectory(string directory)
+        private static void ScheduleModuleDirectoryCleanup(string directory)
         {
             if (!Directory.Exists(directory))
             {
                 return;
             }
 
-            try
+            var cleanup = new Process();
+            cleanup.StartInfo = new ProcessStartInfo();
+            cleanup.StartInfo.UseShellExecute = false;
+            cleanup.StartInfo.CreateNoWindow = true;
+            cleanup.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+            cleanup.StartInfo.Arguments = CleanupArgument + " " + QuoteArgument(directory);
+            cleanup.Start();
+        }
+
+        private static void DeleteModuleDirectory(string directory)
+        {
+            for (var retry = 0; retry < 30; retry++)
             {
-                Directory.Delete(directory, true);
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                try
+                {
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(1000);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(1000);
+                }
             }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
+        }
+
+        private static string QuoteArgument(string argument)
+        {
+            return "\"" + argument.Replace("\"", "\\\"") + "\"";
         }
 
         public static string ReplaceString(string str, string oldValue, string newValue, StringComparison comparison)

--- a/PowerShellToolsPro.Packager/Obfuscator.cs
+++ b/PowerShellToolsPro.Packager/Obfuscator.cs
@@ -20,41 +20,10 @@ namespace PowerShellToolsPro.Packager
             }
             else
             {
-                try
-                {
-                    CorruptPE(assemblyPath);
-                }
-                catch
-                {
-                    return assemblyPath;
-                }
-
+                Output?.Invoke(this, "Skipping obfuscation for PowerShell Core packages because mutating .NET single-file bundle metadata can increase antivirus false positives.");
                 return assemblyPath;
                 //return ObfuscatePS(assemblyPath, destinationPath);
             }
-        }
-
-        private void CorruptPE(string assemblyPath)
-        {
-            var data = File.ReadAllBytes(assemblyPath);
-
-            ReadOnlySpan<byte> bundleSignature = new byte[] {
-				// 32 bytes represent the bundle signature: SHA-256 for ".net core bundle"
-				0x8b, 0x12, 0x02, 0xb9, 0x6a, 0x61, 0x20, 0x38,
-                0x72, 0x7b, 0x93, 0x02, 0x14, 0xd7, 0xa0, 0x32,
-                0x13, 0xf5, 0xb9, 0xe6, 0xef, 0xae, 0x33, 0x18,
-                0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
-            };
-
-            for(var i = 0; i < data.Length; i++)
-            {
-                if (data[i] == 0x8b && bundleSignature.SequenceEqual(new ReadOnlySpan<byte>(data, i, bundleSignature.Length)))
-                {
-                    data[i] = 0x00;
-                }
-            }
-
-            File.WriteAllBytes(assemblyPath, data);
         }
 
         public void ObfuscateWinPS(string assemblyPath, string destinationPath)

--- a/PowerShellToolsPro.Packager/UpdateHostStage.cs
+++ b/PowerShellToolsPro.Packager/UpdateHostStage.cs
@@ -160,13 +160,13 @@ namespace PowerShellToolsPro.Packager
             if (!string.IsNullOrEmpty(process.Config.Package.Certificate))
             {
                 WriteDebugMessage($"Signing assembly with certificate {process.Config.Package.Certificate}");
-                SignAssembly(process.Config.Package.Certificate, targetPath);
+                SignAssembly(process.Config.Package.Certificate, process.Config.Package.TimestampServer, targetPath);
             }
 
             return new StageResult(targetPath, true);
         }
 
-        private void SignAssembly(string certificate, string path)
+        private void SignAssembly(string certificate, string timestampServer, string path)
         {
             X509Certificate2 cert = null;
             using (var ps = PowerShell.Create())
@@ -181,9 +181,14 @@ namespace PowerShellToolsPro.Packager
 
             using (var ps = PowerShell.Create())
             {
-                ps.AddCommand("Set-AuthenticodeSignature")
+                var command = ps.AddCommand("Set-AuthenticodeSignature")
                     .AddParameter("FilePath", path)
                     .AddParameter("Certificate", cert);
+                if (!string.IsNullOrEmpty(timestampServer))
+                {
+                    command.AddParameter("TimestampServer", timestampServer);
+                }
+
                 var result = ps.Invoke().First();
 
                 if (ps.HadErrors)


### PR DESCRIPTION
PowerShell-packaged executables can look suspicious to antivirus heuristics because they combine embedded scripts, bundled resources, hidden process behavior, and optional obfuscation. This change removes a few avoidable signals while preserving the existing packaging model.

## Changes

- Stop mutating .NET single-file bundle metadata for PowerShell Core obfuscation. The packager now skips that path and emits a diagnostic message instead of corrupting the bundle signature.
- Replace hidden `powershell`/`pwsh` cleanup processes with an internal cleanup mode that relaunches the packaged executable itself, waits for parent-process locks to release, and retries temp module deletion out of process.
- Stop forcing `-ExecutionPolicy Unrestricted` in generated PowerShell Core hosts.
- Add optional `Package.TimestampServer` support so Authenticode signatures can be timestamped.

## Validation

- `dotnet build .\PowerShellToolsPro.Packager\PowerShellToolsPro.Packager.csproj -v:minimal`

The full packager test project did not build in this environment because `PowerShellToolsPro.Packager.Test.TestModule` could not resolve `System.Management.Automation`, which appears unrelated to these changes.