### PR TITLE
Fix PSScriptRoot for PowerShell Core packages

### DIFF
--- a/PowerShellToolsPro.Packager.Test/HostTemplateTests.cs
+++ b/PowerShellToolsPro.Packager.Test/HostTemplateTests.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Reflection;
+using PowerShellToolsPro.Packager;
+using Xunit;
+
+namespace PowerShellToolsPro.Test.Packager
+{
+    public class HostTemplateTests
+    {
+        [Theory]
+        [InlineData("PowerShellToolsPro.Packager.Hosts.Console.ConsolePowerShellHost_Core.cs")]
+        [InlineData("PowerShellToolsPro.Packager.Hosts.Console.ConsolePowerShellHost_Linux.cs")]
+        [InlineData("PowerShellToolsPro.Packager.Hosts.Console.ConsolePowerShellHost_Osx.cs")]
+        [InlineData("PowerShellToolsPro.Packager.Hosts.Service.ConsolePowerShellHost_Core.cs")]
+        public void PowerShellCoreHostTemplatesResolveScriptRootFromExecutable(string resourceName)
+        {
+            var hostTemplate = GetEmbeddedResource(resourceName);
+
+            Assert.Contains("Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName)", hostTemplate);
+            Assert.DoesNotContain("Assembly.GetExecutingAssembly().CodeBase", hostTemplate);
+        }
+
+        private static string GetEmbeddedResource(string resourceName)
+        {
+            using (var stream = typeof(Compiler).GetTypeInfo().Assembly.GetManifestResourceStream(resourceName))
+            {
+                Assert.NotNull(stream);
+
+                using (var reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+    }
+}

--- a/PowerShellToolsPro.Packager.Test/PowerShellToolsPro.Packager.Test.csproj
+++ b/PowerShellToolsPro.Packager.Test/PowerShellToolsPro.Packager.Test.csproj
@@ -55,6 +55,7 @@
     <Compile Include="BundlerTests.cs" />
     <Compile Include="ConfigDeserializerTests.cs" />
     <Compile Include="CSharpCodeGeneratorTest.cs" />
+    <Compile Include="HostTemplateTests.cs" />
     <Compile Include="ModuleCompilerTests.cs" />
     <Compile Include="OldCompiler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Core.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Core.cs
@@ -198,10 +198,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
         {
             get
             {
-                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                UriBuilder uri = new UriBuilder(codeBase);
-                string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
+                return Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
             }
         }
 

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Linux.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Linux.cs
@@ -171,10 +171,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
         {
             get
             {
-                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                UriBuilder uri = new UriBuilder(codeBase);
-                string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
+                return Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
             }
         }
 

--- a/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Osx.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Console/ConsolePowerShellHost_Osx.cs
@@ -171,10 +171,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
         {
             get
             {
-                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                UriBuilder uri = new UriBuilder(codeBase);
-                string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
+                return Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
             }
         }
 

--- a/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost_Core.cs
+++ b/PowerShellToolsPro.Packager/Hosts/Service/ConsolePowerShellHost_Core.cs
@@ -233,10 +233,7 @@ namespace PowerShellToolsPro.Packager.ConsoleHost
         {
             get
             {
-                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                UriBuilder uri = new UriBuilder(codeBase);
-                string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
+                return Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
             }
         }
 


### PR DESCRIPTION
PowerShell Core single-file packages were resolving `$PSScriptRoot` from the bundle extraction directory, which caused scripts packaged with Merge-Script to see a temp path instead of the directory where the executable was launched from.

This updates the PowerShell Core host templates to derive `PoshToolsRoot` from the current process executable path rather than `Assembly.GetExecutingAssembly().CodeBase`. That keeps the existing `$PSScriptRoot` replacement behavior but points it at the packaged exe location across Windows, Linux, macOS, and service hosts.

Added regression coverage for the embedded Core host templates.

Fixes #142