### PR TITLE
Fix VS Code canceled event handling

### DIFF
--- a/vscode/powershellprotools/package.json
+++ b/vscode/powershellprotools/package.json
@@ -33,6 +33,7 @@
         "onView:jobView",
         "onCommand:powershell.showWinFormDesigner",
         "onCommand:powershell.generateWinForm",
+        "onCommand:poshProTools.refactoringInfo",
         "onCommand:poshProTools.statusBarMenu",
         "onCommand:poshProTools.installModule",
         "onCommand:poshProTools.welcome"

--- a/vscode/powershellprotools/src/commands/refactoring.ts
+++ b/vscode/powershellprotools/src/commands/refactoring.ts
@@ -6,9 +6,9 @@ import { RefactorInfo, RefactoringProperty, RefactorProperty, RefactorRequest, R
 
 export class RefactoringCommands implements ICommand, vscode.CodeActionProvider {
     async provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<(vscode.CodeAction | vscode.Command)[]> {
-        if (!Container.IsInitialized(false)) return;
+        if (!Container.IsInitialized(false)) return [];
 
-        var request = this.getRefactorRequest();
+        var request = this.createRefactorRequest(range, document);
 
         var validRefactors = await Container.PowerShellService.GetValidRefactors(request);
         var codeActions = new Array<vscode.CodeAction>();
@@ -51,12 +51,15 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
         );
 
         context.subscriptions.push(this.Refactor());
+        context.subscriptions.push(this.RefactoringInfo());
         context.subscriptions.push(this.MoveLeft());
         context.subscriptions.push(this.MoveRight());
     }
 
     async Move(direction: string) {
         var request = this.getRefactorRequest();
+        if (!request) return;
+
         request.type = RefactorType.reorder
         request.properties = [{
             type: RefactorProperty.name,
@@ -87,9 +90,12 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
             if (!Container.IsInitialized()) return;
 
             var request = this.getRefactorRequest();
+            if (!request) return;
 
             var validRefactors = await Container.PowerShellService.GetValidRefactors(request);
             var refactorName = await vscode.window.showQuickPick(validRefactors.map(m => m.Name));
+            if (!refactorName) return;
+
             var refactor = validRefactors.find(m => m.Name === refactorName);
 
             if (!refactor) return;
@@ -112,7 +118,24 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
         })
     }
 
-    createRefactorRequest(selection: vscode.Selection, document: vscode.TextDocument): RefactorRequest {
+    RefactoringInfo() {
+        return vscode.commands.registerCommand('poshProTools.refactoringInfo', async () => {
+            if (!Container.IsInitialized()) return;
+
+            var request = this.getRefactorRequest();
+            if (!request) return;
+
+            var validRefactors = await Container.PowerShellService.GetValidRefactors(request);
+            if (!validRefactors || validRefactors.length === 0) {
+                vscode.window.showInformationMessage("No refactorings are available for the current selection.");
+                return;
+            }
+
+            vscode.window.showInformationMessage(`Available refactorings: ${validRefactors.map(m => m.Name).join(", ")}`);
+        })
+    }
+
+    createRefactorRequest(selection: vscode.Range | vscode.Selection, document: vscode.TextDocument): RefactorRequest {
         var request = new RefactorRequest();
         request.editorState = new TextEditorState();
         request.editorState.content = document.getText()
@@ -126,14 +149,19 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
         var startColumn = selection.start.character;
         var startLine = selection.start.line;
 
-        do {
+        while (startLine < document.lineCount) {
             var line = document.lineAt(startLine);
             if (!line.isEmptyOrWhitespace && line.text[line.firstNonWhitespaceCharacterIndex] != '#') {
                 break;
             }
             startColumn = 0;
             startLine++;
-        } while (startLine < document.lineCount);
+        }
+
+        if (startLine >= document.lineCount) {
+            startLine = selection.start.line;
+            startColumn = selection.start.character;
+        }
 
         request.editorState.selectionStart = {
             Line: startLine,
@@ -160,15 +188,19 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
         return request;
     }
 
-    getRefactorRequest(): RefactorRequest {
-        var selection = vscode.window.activeTextEditor.selection;
-        return this.createRefactorRequest(selection, vscode.window.activeTextEditor.document);
+    getRefactorRequest(): RefactorRequest | undefined {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return undefined;
+
+        return this.createRefactorRequest(editor.selection, editor.document);
     }
 
     async extractVariable(request: RefactorRequest) {
         const name = await vscode.window.showInputBox({
             prompt: "Enter variable name"
         });
+
+        if (!name) return;
 
         request.properties = [{ type: RefactorProperty.name, value: name }];
         request.type = RefactorType.ExtractVariable
@@ -181,6 +213,8 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
             prompt: "Enter function name"
         });
 
+        if (!name) return;
+
         request.properties = [{ type: RefactorProperty.name, value: name }];
         request.type = RefactorType.extractFunction
 
@@ -191,6 +225,8 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
         const fileName = await vscode.window.showInputBox({
             prompt: "Enter file name"
         });
+
+        if (!fileName) return;
 
         request.properties = [{ type: RefactorProperty.fileName, value: fileName }];
         request.type = RefactorType.extractFile

--- a/vscode/powershellprotools/src/commands/reflection.ts
+++ b/vscode/powershellprotools/src/commands/reflection.ts
@@ -36,7 +36,7 @@ export class ReflectionCommands implements ICommand {
         return vscode.commands.registerCommand('poshProTools.loadAssembly', async () => {
             if (!Container.IsInitialized()) return;
 
-            const result = await vscode.window.showOpenDialog({
+            const assemblies = await vscode.window.showOpenDialog({
                 canSelectFiles: true,
                 canSelectFolders: false,
                 canSelectMany: true,
@@ -45,9 +45,11 @@ export class ReflectionCommands implements ICommand {
                 }
             });
 
-            result.forEach(async x => {
-                Container.PowerShellService.LoadAssembly(x.fsPath);
-            });
+            if (!assemblies || assemblies.length === 0) return;
+
+            for (const assembly of assemblies) {
+                await Container.PowerShellService.LoadAssembly(assembly.fsPath);
+            }
 
             await vscode.commands.executeCommand('reflectionView.refresh')
         })

--- a/vscode/powershellprotools/src/commands/sessions.ts
+++ b/vscode/powershellprotools/src/commands/sessions.ts
@@ -54,7 +54,10 @@ export class SessionCommands implements ICommand {
 
     UnpinSession() {
         return vscode.commands.registerCommand('poshProTools.unpinSession', async () => {
-            this._pinnedTextEditors.delete(vscode.window.activeTextEditor.document.uri);
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) return;
+
+            this._pinnedTextEditors.delete(editor.document.uri);
             this._statusBarItem.hide();
         });
     }
@@ -67,16 +70,22 @@ export class SessionCommands implements ICommand {
             if (!Container.IsInitialized()) return;
 
             const sessions = await Container.PowerShellService.GetSessions();
+            const editor = vscode.window.activeTextEditor;
 
             if (sessions.length === 0 || (sessions.length === 1 && sessions[0] == null)) {
                 vscode.window.showWarningMessage("No sessions to pin.");
                 return;
             }
 
-            const result = await vscode.window.showQuickPick(sessions.map(x => x.Name));
-            const session = sessions.find(x => x.Name === result);
+            if (!editor) return;
 
-            this._pinnedTextEditors.set(vscode.window.activeTextEditor.document.uri, session);
+            const result = await vscode.window.showQuickPick(sessions.map(x => x.Name));
+            if (!result) return;
+
+            const session = sessions.find(x => x.Name === result);
+            if (!session) return;
+
+            this._pinnedTextEditors.set(editor.document.uri, session);
 
             if (this._runspacePushed) {
                 this._runspacePushed = false;
@@ -89,6 +98,8 @@ export class SessionCommands implements ICommand {
             this._statusBarItem.show();
 
             vscode.window.onDidChangeActiveTextEditor(async (editor) => {
+                if (!editor) return;
+
                 if (this._runspacePushed) {
                     this._runspacePushed = false;
                     await Container.PowerShellService.ExitSession();

--- a/vscode/powershellprotools/src/commands/signOnSave.ts
+++ b/vscode/powershellprotools/src/commands/signOnSave.ts
@@ -21,6 +21,9 @@ export function signOnSave() {
                 const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(PowerShellLanguageId);
                 await configuration.update('signOnSaveCertificate', selectedCert);
             }
+            else {
+                return;
+            }
         }
 
         await Container.PowerShellService.SignScript(x.fileName, selectedCert);


### PR DESCRIPTION
Canceling or dismissing VS Code dialogs and picker UI could leave extension commands handling `undefined` as a valid result, which surfaced as unhandled extension host errors during normal user actions.

This updates the affected VS Code extension paths to treat canceled UI as a no-op, uses the document/range supplied by VS Code code-action events instead of assuming an active editor, and registers the contributed refactoring info command so invoking it directly no longer fails as missing.

Validated with `npm run compile` in `vscode\powershellprotools`.

Fixes #137