### PR TITLE
Add Convert to Splat command

### DIFF
--- a/vscode/powershellprotools/package.json
+++ b/vscode/powershellprotools/package.json
@@ -34,6 +34,7 @@
         "onCommand:powershell.showWinFormDesigner",
         "onCommand:powershell.generateWinForm",
         "onCommand:poshProTools.refactoringInfo",
+        "onCommand:poshProTools.convertToSplat",
         "onCommand:poshProTools.statusBarMenu",
         "onCommand:poshProTools.installModule",
         "onCommand:poshProTools.welcome"
@@ -49,6 +50,11 @@
             {
                 "command": "poshProTools.refactoringInfo",
                 "title": "Refactoring Info",
+                "category": "PowerShell Pro Tools"
+            },
+            {
+                "command": "poshProTools.convertToSplat",
+                "title": "Convert to Splat",
                 "category": "PowerShell Pro Tools"
             },
             {

--- a/vscode/powershellprotools/src/commands/refactoring.ts
+++ b/vscode/powershellprotools/src/commands/refactoring.ts
@@ -54,6 +54,7 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
         context.subscriptions.push(this.RefactoringInfo());
         context.subscriptions.push(this.MoveLeft());
         context.subscriptions.push(this.MoveRight());
+        context.subscriptions.push(this.ConvertToSplat());
     }
 
     async Move(direction: string) {
@@ -132,6 +133,18 @@ export class RefactoringCommands implements ICommand, vscode.CodeActionProvider 
             }
 
             vscode.window.showInformationMessage(`Available refactorings: ${validRefactors.map(m => m.Name).join(", ")}`);
+        })
+    }
+
+    ConvertToSplat() {
+        return vscode.commands.registerCommand('poshProTools.convertToSplat', async () => {
+            if (!Container.IsInitialized()) return;
+
+            var request = this.getRefactorRequest();
+            if (!request) return;
+
+            request.type = RefactorType.convertToSplat;
+            await this.requestRefactor(request);
         })
     }
 


### PR DESCRIPTION
The Convert to Splat refactoring was only available through the refactoring UI, which made it hard to assign directly to a custom keyboard shortcut. This exposes the existing refactoring as its own VS Code command so users can bind it from Keyboard Shortcuts or invoke it from the command palette.

The implementation registers `poshProTools.convertToSplat` alongside the existing refactoring commands and contributes it in the extension manifest without adding a default keybinding.

Fixes #148