### PR TITLE
Fix VS Code extract function refactoring

### DIFF
--- a/HostInjection/Refactoring/ExtractFunction.cs
+++ b/HostInjection/Refactoring/ExtractFunction.cs
@@ -10,6 +10,11 @@ namespace PowerShellProTools.Host.Refactoring
     {
         public RefactorInfo RefactorInfo => new RefactorInfo("Extract function", RefactorType.ExtractFunction);
 
+        private static readonly string[] AutomaticVariables = new[]
+        {
+            "_", "PSItem", "null", "true", "false", "this", "args", "input", "host", "error", "foreach", "switch"
+        };
+
         public bool CanRefactor(TextEditorState state, Ast ast, IEnumerable<RefactoringProperty> properties)
         {
             return state.SelectionStart.Line < state.SelectionEnd.Line || state.SelectionEnd.Character > state.SelectionStart.Character;
@@ -37,41 +42,53 @@ namespace PowerShellProTools.Host.Refactoring
                 name = "MyFunction";
             }
 
-            var assignmentsBeforeSelection = ast.FindAll(m =>
-                m.Extent.EndLineNumber < startExtent.StartLineNumber &&
-                m is AssignmentStatementAst assignment &&
-                assignment.Left is VariableExpressionAst, true)
-                .Cast<AssignmentStatementAst>()
-                .Select(m => m.Left as VariableExpressionAst);
-
-            var assignmentsAfterSelection = ast.FindAll(m =>
-                m.Extent.StartLineNumber > endExtent.EndLineNumber &&
-                m is VariableExpressionAst, true)
-                .Cast<VariableExpressionAst>();
-
             var variablesInSelection = ast.FindAll(m =>
                 m.Extent.StartLineNumber >= startExtent.StartLineNumber &&
                 m.Extent.EndLineNumber <= endExtent.EndLineNumber &&
                 m is VariableExpressionAst, true)
-                .Cast<VariableExpressionAst>();
+                .Cast<VariableExpressionAst>()
+                .Where(m => !AutomaticVariables.Contains(m.VariablePath.UserPath, StringComparer.OrdinalIgnoreCase))
+                .OrderBy(m => m.Extent.StartOffset)
+                .ToArray();
 
             var stringBuilder = new StringBuilder();
-
-            stringBuilder.AppendLine($"function {name}");
-            stringBuilder.AppendLine("{");
-
-            var parameters = assignmentsBeforeSelection
-                .Where(m => variablesInSelection
-                    .Any(x => x.VariablePath.UserPath.Equals(m.VariablePath.UserPath, StringComparison.OrdinalIgnoreCase)))
-                .Select(m => "$" + m.VariablePath.UserPath);
-
-            if (parameters.Any())
+            var parameters = GetParameters(variablesInSelection);
+            var replacementStartOffset = GetLineStartOffset(state.Content, startExtent.StartOffset);
+            var replacementStartCharacter = startExtent.StartOffset - replacementStartOffset;
+            var baseIndent = state.Content.Substring(replacementStartOffset, replacementStartCharacter);
+            if (!baseIndent.All(char.IsWhiteSpace))
             {
-                stringBuilder.AppendLine($"\tparam({parameters.Aggregate((x, y) => x + ", " + y)})");
+                replacementStartOffset = startExtent.StartOffset;
+                replacementStartCharacter = startExtent.StartColumnNumber - 1;
+                baseIndent = string.Empty;
             }
 
-            stringBuilder.AppendLine(state.Content.Substring(startExtent.StartOffset, endExtent.EndOffset - startExtent.StartOffset));
-            stringBuilder.AppendLine("}");
+            const string indent = "    ";
+
+            stringBuilder.AppendLine($"{baseIndent}function {name}");
+            stringBuilder.AppendLine($"{baseIndent}{{");
+            if (parameters.Any())
+            {
+                stringBuilder.AppendLine($"{baseIndent}{indent}param(");
+
+                for (int i = 0; i < parameters.Count; i++)
+                {
+                    var parameter = parameters[i];
+                    var suffix = i == parameters.Count - 1 ? string.Empty : ",";
+                    stringBuilder.AppendLine($"{baseIndent}{indent}{indent}{parameter.Type}${parameter.Name}{suffix}");
+                }
+
+                stringBuilder.AppendLine($"{baseIndent}{indent})");
+                stringBuilder.AppendLine();
+            }
+
+            var selectedText = state.Content.Substring(replacementStartOffset, endExtent.EndOffset - replacementStartOffset);
+            foreach (var line in NormalizeIndent(selectedText, baseIndent))
+            {
+                stringBuilder.AppendLine($"{baseIndent}{indent}{line}");
+            }
+
+            stringBuilder.AppendLine($"{baseIndent}}}");
 
             yield return new TextEdit
             {
@@ -80,8 +97,8 @@ namespace PowerShellProTools.Host.Refactoring
                 Start = new TextPosition
                 {
                     Line = startExtent.StartLineNumber - 1,
-                    Character = startExtent.StartColumnNumber - 1,
-                    Index = startExtent.StartOffset
+                    Character = replacementStartCharacter,
+                    Index = replacementStartOffset
                 },
                 End = new TextPosition
                 {
@@ -92,6 +109,108 @@ namespace PowerShellProTools.Host.Refactoring
                 FileName = state.FileName,
                 Type = TextEditType.Replace
             };
+        }
+
+        private static List<ParameterInfo> GetParameters(IEnumerable<VariableExpressionAst> variables)
+        {
+            var assignedVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var parameters = new List<ParameterInfo>();
+
+            foreach (var variable in variables)
+            {
+                var variableName = variable.VariablePath.UserPath;
+                var assignment = variable.FindParent<AssignmentStatementAst>();
+                var isAssignmentTarget = assignment?.Left.FindAll(m => ReferenceEquals(m, variable), true).Any() == true || ReferenceEquals(assignment?.Left, variable);
+
+                if (isAssignmentTarget)
+                {
+                    if (assignment.Operator != TokenKind.Equals && !assignedVariables.Contains(variableName))
+                    {
+                        AddParameter(parameters, variable);
+                    }
+
+                    if (assignment.Right.FindAll(m => m is VariableExpressionAst rightVariable &&
+                        rightVariable.VariablePath.UserPath.Equals(variableName, StringComparison.OrdinalIgnoreCase), true).Any())
+                    {
+                        AddParameter(parameters, variable);
+                    }
+
+                    assignedVariables.Add(variableName);
+                    continue;
+                }
+
+                if (!assignedVariables.Contains(variableName))
+                {
+                    AddParameter(parameters, variable);
+                }
+            }
+
+            return parameters;
+        }
+
+        private static void AddParameter(List<ParameterInfo> parameters, VariableExpressionAst variable)
+        {
+            if (parameters.Any(m => m.Name.Equals(variable.VariablePath.UserPath, StringComparison.OrdinalIgnoreCase)))
+            {
+                return;
+            }
+
+            parameters.Add(new ParameterInfo
+            {
+                Name = variable.VariablePath.UserPath,
+                Type = GetParameterType(variable)
+            });
+        }
+
+        private static string GetParameterType(VariableExpressionAst variable)
+        {
+            var convertExpression = variable.FindParent<ConvertExpressionAst>();
+            if (convertExpression != null && convertExpression.Extent.StartOffset <= variable.Extent.StartOffset && convertExpression.Extent.EndOffset >= variable.Extent.EndOffset)
+            {
+                return $"[{convertExpression.Type.TypeName.FullName}]";
+            }
+
+            var binaryExpression = variable.FindParent<BinaryExpressionAst>();
+            if (binaryExpression != null &&
+                (binaryExpression.Left is StringConstantExpressionAst || binaryExpression.Right is StringConstantExpressionAst))
+            {
+                return "[string]";
+            }
+
+            var command = variable.FindParent<CommandAst>();
+            if (command != null)
+            {
+                for (int i = 0; i < command.CommandElements.Count - 1; i++)
+                {
+                    if (command.CommandElements[i] is CommandParameterAst parameter &&
+                        command.CommandElements[i + 1].Extent.StartOffset == variable.Extent.StartOffset &&
+                        (parameter.ParameterName.Equals("Path", StringComparison.OrdinalIgnoreCase) ||
+                         parameter.ParameterName.Equals("LiteralPath", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        return "[string]";
+                    }
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static int GetLineStartOffset(string content, int offset)
+        {
+            var lineStart = content.LastIndexOf('\n', Math.Max(0, offset - 1));
+            return lineStart == -1 ? 0 : lineStart + 1;
+        }
+
+        private static IEnumerable<string> NormalizeIndent(string text, string baseIndent)
+        {
+            return text.Replace("\r\n", "\n").Split('\n')
+                .Select(line => line.StartsWith(baseIndent) ? line.Substring(baseIndent.Length) : line);
+        }
+
+        private class ParameterInfo
+        {
+            public string Name { get; set; }
+            public string Type { get; set; }
         }
     }
 }

--- a/PowerShellProTools.Host.Tests/Refactoring/ExtractFunctionTests.cs
+++ b/PowerShellProTools.Host.Tests/Refactoring/ExtractFunctionTests.cs
@@ -37,7 +37,7 @@ namespace PowerShellProTools.Host.Tests.Refactoring
                 },
                 Type = RefactorType.ExtractFunction
             });
-            Assert.Equal("function Start-Function\r\n{\r\n\tparam($Variable)\r\nStart-Process $Variable\r\n}\r\n", result.Last().Content);
+            Assert.Equal("function Start-Function\r\n{\r\n    param(\r\n        $Variable\r\n    )\r\n\r\n    Start-Process $Variable\r\n}\r\n", result.Last().Content);
             Assert.Equal(TextEditType.Replace, result.Last().Type);
             Assert.Equal("C:\\MyFile.ps1", result.Last().FileName);
             Assert.Equal(2, result.Last().Start.Line);
@@ -74,13 +74,99 @@ namespace PowerShellProTools.Host.Tests.Refactoring
                 },
                 Type = RefactorType.ExtractFunction
             });
-            Assert.Equal("function Start-Function\r\n{\r\nStart-Process\r\n}\r\n", result.Last().Content);
+            Assert.Equal("function Start-Function\r\n{\r\n    Start-Process\r\n}\r\n", result.Last().Content);
             Assert.Equal(TextEditType.Replace, result.Last().Type);
             Assert.Equal("C:\\MyFile.ps1", result.Last().FileName);
             Assert.Equal(1, result.Last().Start.Line);
             Assert.Equal(0, result.Last().Start.Character);
             Assert.Equal(1, result.Last().End.Line);
             Assert.Equal(13, result.Last().End.Character);
+        }
+
+        [Fact]
+        public void ShouldExtractIndentedFunctionWithReadBeforeWriteParameters()
+        {
+            var content = "    if($ParamSet -eq 'Name') {\r\n" +
+                          "        $Filter = \"`$_.DisplayName -like '$CurrentApp'\"\r\n" +
+                          "    } elseif($ParamSet -eq 'GUID') {\r\n" +
+                          "        # format GUID as brackets w/ hyphens\r\n" +
+                          "        $CurrentApp = $CurrentApp.ToString('b')\r\n" +
+                          "        $Filter = \"`$_.PSChildName -eq '$($CurrentApp.ToString('b'))'\"\r\n" +
+                          "    }\r\n" +
+                          "\r\n" +
+                          "    if($Version) {\r\n" +
+                          "        $Filter += \" -and [version]'$Version' -ge `$_.DisplayVersion\"\r\n" +
+                          "    }\r\n" +
+                          "\r\n" +
+                          "    $Filter += \" -and `$_.UninstallString -ne `$null\"\r\n" +
+                          "    $FilterScript = [scriptblock]::Create($Filter)\r\n" +
+                          "\r\n" +
+                          "    $Results = @(Get-ItemProperty -Path $RegKeys | Where-Object -FilterScript $FilterScript)\r\n" +
+                          "\r\n" +
+                          "    log \"Found $($Results.Count) applications matching $CurrentApp $Version\"";
+
+            var textEditorState = new TextEditorState
+            {
+                Content = content,
+                FileName = "C:\\MyFile.ps1",
+                SelectionStart = new TextPosition
+                {
+                    Line = 0,
+                    Character = 0
+                },
+                SelectionEnd = new TextPosition
+                {
+                    Line = 17,
+                    Character = 72
+                }
+            };
+
+            var result = RefactorService.Refactor(new RefactorRequest
+            {
+                EditorState = textEditorState,
+                Properties = new List<RefactoringProperty>
+                {
+                    new RefactoringProperty { Type = RefactorProperty.Name, Value = "FuncName" }
+                },
+                Type = RefactorType.ExtractFunction
+            });
+
+            var expected = "    function FuncName\r\n" +
+                           "    {\r\n" +
+                           "        param(\r\n" +
+                           "            [string]$ParamSet,\r\n" +
+                           "            $CurrentApp,\r\n" +
+                           "            [version]$Version,\r\n" +
+                           "            [string]$RegKeys\r\n" +
+                           "        )\r\n" +
+                           "\r\n" +
+                           "        if($ParamSet -eq 'Name') {\r\n" +
+                           "            $Filter = \"`$_.DisplayName -like '$CurrentApp'\"\r\n" +
+                           "        } elseif($ParamSet -eq 'GUID') {\r\n" +
+                           "            # format GUID as brackets w/ hyphens\r\n" +
+                           "            $CurrentApp = $CurrentApp.ToString('b')\r\n" +
+                           "            $Filter = \"`$_.PSChildName -eq '$($CurrentApp.ToString('b'))'\"\r\n" +
+                           "        }\r\n" +
+                           "\r\n" +
+                           "        if($Version) {\r\n" +
+                           "            $Filter += \" -and [version]'$Version' -ge `$_.DisplayVersion\"\r\n" +
+                           "        }\r\n" +
+                           "\r\n" +
+                           "        $Filter += \" -and `$_.UninstallString -ne `$null\"\r\n" +
+                           "        $FilterScript = [scriptblock]::Create($Filter)\r\n" +
+                           "\r\n" +
+                           "        $Results = @(Get-ItemProperty -Path $RegKeys | Where-Object -FilterScript $FilterScript)\r\n" +
+                           "\r\n" +
+                           "        log \"Found $($Results.Count) applications matching $CurrentApp $Version\"\r\n" +
+                           "    }\r\n";
+
+            Assert.Equal(expected, result.Last().Content);
+            Assert.Equal(TextEditType.Replace, result.Last().Type);
+            Assert.Equal("C:\\MyFile.ps1", result.Last().FileName);
+            Assert.Equal(0, result.Last().Start.Line);
+            Assert.Equal(0, result.Last().Start.Character);
+            Assert.Equal(17, result.Last().End.Line);
+            Assert.Equal(76, result.Last().End.Character);
         }
     }
 }


### PR DESCRIPTION
The VS Code extract-function refactor produced poorly formatted functions and duplicate or missing parameters for selected PowerShell blocks. This updates extraction to preserve the selected block's base indentation, indent the generated function body consistently, and derive parameters from variables that are read before being assigned within the selection.

The parameter generation now de-duplicates variables, ignores common automatic variables, includes read-before-write assignment cases, and adds simple type hints when the AST makes them clear, such as string comparisons, casts, and path arguments. Regression tests cover the reported indented selection scenario and update the existing extract-function expectations.