### PR TITLE
Fix function rename symbol edits

### DIFF
--- a/HostInjection/Refactoring/RenameSymbol.cs
+++ b/HostInjection/Refactoring/RenameSymbol.cs
@@ -13,6 +13,55 @@ namespace PowerShellProTools.Common.Refactoring
         public IEnumerable<TextEdit> Refactor(string newName, TextEditorState state, Ast ast, Workspace workspace)
         {
             var results = new List<TextEdit>();
+
+            var functionName = GetFunctionNameUnderCursor(state, ast);
+            if (functionName != null)
+            {
+                var functions = ast.FindAll(m => m is FunctionDefinitionAst function && function.Name.Equals(functionName, StringComparison.OrdinalIgnoreCase), true).Cast<FunctionDefinitionAst>().ToArray();
+                if (functions.Any())
+                {
+                    foreach (var function in functions)
+                    {
+                        var definitionEdit = CreateFunctionDefinitionEdit(newName, state.FileName, function);
+                        if (definitionEdit != null)
+                        {
+                            results.Add(definitionEdit);
+                        }
+                    }
+
+                    var commands = ast.FindAll(m => m is CommandAst command && command.GetCommandName()?.Equals(functionName, StringComparison.OrdinalIgnoreCase) == true, true).Cast<CommandAst>();
+                    foreach (var command in commands)
+                    {
+                        var commandName = command.CommandElements.FirstOrDefault();
+                        if (commandName == null)
+                        {
+                            continue;
+                        }
+
+                        results.Add(new TextEdit
+                        {
+                            Content = newName,
+                            FileName = state.FileName,
+                            Type = TextEditType.Replace,
+                            Start = new TextPosition
+                            {
+                                Character = commandName.Extent.StartColumnNumber - 1,
+                                Line = commandName.Extent.StartLineNumber - 1,
+                                Index = commandName.Extent.StartOffset
+                            },
+                            End = new TextPosition
+                            {
+                                Character = commandName.Extent.EndColumnNumber - 1,
+                                Line = commandName.Extent.EndLineNumber - 1,
+                                Index = commandName.Extent.EndOffset
+                            }
+                        });
+                    }
+
+                    return results.Distinct();
+                }
+            }
+
             var variable = ast.GetAstUnderCursor<VariableExpressionAst>(state);
             if (variable != null)
             {
@@ -97,14 +146,84 @@ namespace PowerShellProTools.Common.Refactoring
             }
 
             return results.Distinct();
+        }
 
-            //var function = ast.GetAstUnderCursor<FunctionDefinitionAst>(state);
-            //if (function == null) yield break;
+        private static string GetFunctionNameUnderCursor(TextEditorState state, Ast ast)
+        {
+            var function = ast.FindAll(m => m is FunctionDefinitionAst, true)
+                .Cast<FunctionDefinitionAst>()
+                .FirstOrDefault(m =>
+                {
+                    var edit = CreateFunctionDefinitionEdit(m.Name, state.FileName, m);
+                    return edit != null && ContainsPosition(edit.Start, edit.End, state.SelectionStart);
+                });
 
-            //var functionInfo = workspace.FunctionDefinitions.FirstOrDefault(m => m.Name.Equals(function.Name, StringComparison.OrdinalIgnoreCase));
-            //if (functionInfo == null) yield break;
+            if (function != null)
+            {
+                return function.Name;
+            }
 
+            var command = ast.FindAll(m => m is CommandAst, true)
+                .Cast<CommandAst>()
+                .FirstOrDefault(m =>
+                {
+                    var commandName = m.CommandElements.FirstOrDefault();
+                    return commandName != null && ContainsPosition(commandName.Extent, state.SelectionStart);
+                });
 
+            return command?.GetCommandName();
+        }
+
+        private static TextEdit CreateFunctionDefinitionEdit(string newName, string fileName, FunctionDefinitionAst function)
+        {
+            var firstLine = function.Extent.Text.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None).FirstOrDefault();
+            if (firstLine == null)
+            {
+                return null;
+            }
+
+            var nameIndex = firstLine.IndexOf(function.Name, StringComparison.OrdinalIgnoreCase);
+            if (nameIndex < 0)
+            {
+                return null;
+            }
+
+            var startCharacter = function.Extent.StartColumnNumber - 1 + nameIndex;
+
+            return new TextEdit
+            {
+                Content = newName,
+                FileName = fileName,
+                Type = TextEditType.Replace,
+                Start = new TextPosition
+                {
+                    Character = startCharacter,
+                    Line = function.Extent.StartLineNumber - 1,
+                    Index = function.Extent.StartOffset + nameIndex
+                },
+                End = new TextPosition
+                {
+                    Character = startCharacter + function.Name.Length,
+                    Line = function.Extent.StartLineNumber - 1,
+                    Index = function.Extent.StartOffset + nameIndex + function.Name.Length
+                }
+            };
+        }
+
+        private static bool ContainsPosition(IScriptExtent extent, TextPosition position)
+        {
+            return extent.StartLineNumber <= position.Line + 1 &&
+                extent.EndLineNumber >= position.Line + 1 &&
+                extent.StartColumnNumber <= position.Character + 1 &&
+                extent.EndColumnNumber >= position.Character + 1;
+        }
+
+        private static bool ContainsPosition(TextPosition start, TextPosition end, TextPosition position)
+        {
+            return start.Line <= position.Line &&
+                end.Line >= position.Line &&
+                start.Character <= position.Character &&
+                end.Character >= position.Character;
         }
     }
 }

--- a/PowerShellProTools.Host.Tests/Refactoring/RenameSymbolTests.cs
+++ b/PowerShellProTools.Host.Tests/Refactoring/RenameSymbolTests.cs
@@ -1,0 +1,102 @@
+﻿using PowerShellProTools.Common.Refactoring;
+using PowerShellProTools.Host;
+using PowerShellProTools.Host.Refactoring;
+using System.Linq;
+using System.Management.Automation.Language;
+using Xunit;
+
+namespace PowerShellProTools.Host.Tests.Refactoring
+{
+    public class RenameSymbolTests
+    {
+        [Fact]
+        public void ShouldRenameFunctionDefinitionAndReferences()
+        {
+            var textEditorState = new TextEditorState
+            {
+                Content = "function Get-Thing {\r\n}\r\nGet-Thing\r\n",
+                FileName = "C:\\MyFile.psm1",
+                SelectionStart = new TextPosition
+                {
+                    Line = 0,
+                    Character = 10
+                },
+                SelectionEnd = new TextPosition
+                {
+                    Line = 0,
+                    Character = 10
+                }
+            };
+
+            var ast = Parser.ParseInput(textEditorState.Content, out Token[] tokens, out ParseError[] errors);
+            var result = new RenameSymbol().Refactor("Get-ItemThing", textEditorState, ast, new Workspace("C:\\")).ToArray();
+
+            Assert.Equal(2, result.Length);
+            Assert.All(result, edit => Assert.Equal("Get-ItemThing", edit.Content));
+            Assert.Equal(TextEditType.Replace, result[0].Type);
+            Assert.Equal(0, result[0].Start.Line);
+            Assert.Equal(9, result[0].Start.Character);
+            Assert.Equal(0, result[0].End.Line);
+            Assert.Equal(18, result[0].End.Character);
+            Assert.Equal(2, result[1].Start.Line);
+            Assert.Equal(0, result[1].Start.Character);
+            Assert.Equal(2, result[1].End.Line);
+            Assert.Equal(9, result[1].End.Character);
+        }
+
+        [Fact]
+        public void ShouldRenameFunctionFromReference()
+        {
+            var textEditorState = new TextEditorState
+            {
+                Content = "function Get-Thing {\r\n}\r\nGet-Thing\r\n",
+                FileName = "C:\\MyFile.psm1",
+                SelectionStart = new TextPosition
+                {
+                    Line = 2,
+                    Character = 1
+                },
+                SelectionEnd = new TextPosition
+                {
+                    Line = 2,
+                    Character = 1
+                }
+            };
+
+            var ast = Parser.ParseInput(textEditorState.Content, out Token[] tokens, out ParseError[] errors);
+            var result = new RenameSymbol().Refactor("Get-ItemThing", textEditorState, ast, new Workspace("C:\\")).ToArray();
+
+            Assert.Equal(2, result.Length);
+            Assert.All(result, edit => Assert.Equal("Get-ItemThing", edit.Content));
+            Assert.Equal(0, result[0].Start.Line);
+            Assert.Equal(9, result[0].Start.Character);
+            Assert.Equal(2, result[1].Start.Line);
+            Assert.Equal(0, result[1].Start.Character);
+        }
+
+        [Fact]
+        public void ShouldNotRenameCommandsWithoutFunctionDefinitions()
+        {
+            var textEditorState = new TextEditorState
+            {
+                Content = "Get-Process\r\n",
+                FileName = "C:\\MyFile.psm1",
+                SelectionStart = new TextPosition
+                {
+                    Line = 0,
+                    Character = 1
+                },
+                SelectionEnd = new TextPosition
+                {
+                    Line = 0,
+                    Character = 1
+                }
+            };
+
+            var ast = Parser.ParseInput(textEditorState.Content, out Token[] tokens, out ParseError[] errors);
+            var result = new RenameSymbol().Refactor("Get-SomethingElse", textEditorState, ast, new Workspace("C:\\")).ToArray();
+
+            Assert.Empty(result);
+        }
+    }
+}


### PR DESCRIPTION
Rename Symbol showed the VS Code rename UI for PowerShell functions but returned no edits, so pressing Enter appeared to do nothing.

This adds backend rename support for functions by detecting the function name under the cursor, producing replacement edits for matching local function definitions and same-file call sites, and leaving unrelated commands untouched when no local function definition exists. It also adds host refactoring tests for renaming from both a definition and a reference.

Closes #138

Tests:
- `dotnet test .\PowerShellProTools.Host.Tests\PowerShellProTools.Host.Tests.csproj --no-restore`