### PR TITLE
Fix form designer stub insertion order

### DIFF
--- a/FormDesigner.Test/FormGeneratorTest.cs
+++ b/FormDesigner.Test/FormGeneratorTest.cs
@@ -36,5 +36,38 @@ namespace PowerShellToolsPro.Test.FormsDesigner
 
             //Assert.Equal(expected, formCode);
         }
+
+        [Fact]
+        public void ShouldInsertStubAfterRequiresUsingAndParamBlock()
+        {
+            var script = "#requires -version 5.1\r\nusing namespace System.Windows.Forms\r\nparam(\r\n    [string]$Name\r\n)\r\nWrite-Host $Name";
+            var stub = "$button1_Click = {\r\n\r\n}\r\n\r\n";
+
+            var result = PowerShellCodeDomProvider.InsertTextAfterScriptPreamble(script, stub);
+
+            Assert.Equal("#requires -version 5.1\r\nusing namespace System.Windows.Forms\r\nparam(\r\n    [string]$Name\r\n)\r\n$button1_Click = {\r\n\r\n}\r\n\r\nWrite-Host $Name", result);
+        }
+
+        [Fact]
+        public void ShouldInsertStubAfterSingleLineParamBlock()
+        {
+            var script = "param([string]$Name)\r\nWrite-Host $Name";
+            var stub = "function button1_Click {\r\n}\r\n\r\n";
+
+            var result = PowerShellCodeDomProvider.InsertTextAfterScriptPreamble(script, stub);
+
+            Assert.Equal("param([string]$Name)\r\nfunction button1_Click {\r\n}\r\n\r\nWrite-Host $Name", result);
+        }
+
+        [Fact]
+        public void ShouldInsertStubAtBeginningWhenNoPreambleExists()
+        {
+            var script = "Write-Host 'Ready'";
+            var stub = "$button1_Click = {\r\n\r\n}\r\n\r\n";
+
+            var result = PowerShellCodeDomProvider.InsertTextAfterScriptPreamble(script, stub);
+
+            Assert.Equal("$button1_Click = {\r\n\r\n}\r\n\r\nWrite-Host 'Ready'", result);
+        }
     }
 }

--- a/FormDesigner/CodeDom/CommandLineCodeDomProvider.cs
+++ b/FormDesigner/CodeDom/CommandLineCodeDomProvider.cs
@@ -60,9 +60,10 @@ namespace IM.CodeDom
             return _designerFileName;
         }
 
-        public override void InsertIntoBeginningOfFile(string fileName, string text)
+        protected override void InsertIntoFile(string fileName, string text, int offset)
         {
-            
+            var contents = File.ReadAllText(fileName);
+            File.WriteAllText(fileName, contents.Insert(offset, text));
         }
 
         protected override void Log(string message)

--- a/FormDesigner/CodeDom/PowerShellCodeDomProvider.cs
+++ b/FormDesigner/CodeDom/PowerShellCodeDomProvider.cs
@@ -31,7 +31,70 @@ namespace PowerShellToolsPro.FormsDesigner
         public abstract string GetCodeFileName(TextReader codeStream);
         public abstract string GetCodeFileName(TextWriter codeStream);
 
-        public abstract void InsertIntoBeginningOfFile(string fileName, string text);
+        public void InsertAfterScriptPreamble(string fileName, string text)
+        {
+            var contents = File.ReadAllText(fileName);
+            InsertIntoFile(fileName, text, GetScriptPreambleInsertionOffset(contents));
+        }
+
+        public static string InsertTextAfterScriptPreamble(string contents, string text)
+        {
+            return contents.Insert(GetScriptPreambleInsertionOffset(contents), text);
+        }
+
+        public static int GetScriptPreambleInsertionOffset(string contents)
+        {
+            if (string.IsNullOrEmpty(contents))
+            {
+                return 0;
+            }
+
+            var insertionOffset = 0;
+            var ast = Parser.ParseInput(contents, out Token[] tokens, out ParseError[] parseErrors);
+            var scriptBlockAst = ast as ScriptBlockAst;
+
+            if (scriptBlockAst != null)
+            {
+                var usingStatements = scriptBlockAst.FindAll(m => m is UsingStatementAst, true).Cast<UsingStatementAst>();
+                foreach (var usingStatement in usingStatements)
+                {
+                    insertionOffset = Math.Max(insertionOffset, usingStatement.Extent.EndOffset);
+                }
+
+                if (scriptBlockAst.ParamBlock != null)
+                {
+                    insertionOffset = Math.Max(insertionOffset, scriptBlockAst.ParamBlock.Extent.EndOffset);
+                }
+            }
+
+            foreach (Match match in Regex.Matches(contents, @"^[ \t]*#requires\b[^\r\n]*(?:\r\n|\n|\r)?", RegexOptions.IgnoreCase | RegexOptions.Multiline))
+            {
+                insertionOffset = Math.Max(insertionOffset, match.Index + match.Length);
+            }
+
+            return AdvancePastLineEnding(contents, insertionOffset);
+        }
+
+        protected abstract void InsertIntoFile(string fileName, string text, int offset);
+
+        private static int AdvancePastLineEnding(string contents, int offset)
+        {
+            if (offset < contents.Length && contents[offset] == '\r')
+            {
+                offset++;
+
+                if (offset < contents.Length && contents[offset] == '\n')
+                {
+                    offset++;
+                }
+            }
+            else if (offset < contents.Length && contents[offset] == '\n')
+            {
+                offset++;
+            }
+
+            return offset;
+        }
 
         private readonly EventGenerationType _eventGenerationType;
 
@@ -264,9 +327,7 @@ namespace PowerShellToolsPro.FormsDesigner
                     var assignment = ast.Find(m => m is FunctionDefinitionAst fda && fda.Name.Equals(methodName, StringComparison.OrdinalIgnoreCase), true);
                     if (assignment == null)
                     {
-                        var contents = File.ReadAllText(_ps1FileName);
-                        contents = $"function {methodName} {{{Environment.NewLine}}}{Environment.NewLine}{contents}";
-                        File.WriteAllText(_ps1FileName, contents);
+                        powerShellCodeDomProvider.InsertAfterScriptPreamble(_ps1FileName, $"function {methodName} {{{Environment.NewLine}}}{Environment.NewLine}");
                     }
                 }
             }
@@ -280,9 +341,7 @@ namespace PowerShellToolsPro.FormsDesigner
                     var assignment = ast.Find(m => m is AssignmentStatementAst asa && asa.Left is VariableExpressionAst vea && vea.VariablePath.UserPath.Equals(methodName, StringComparison.OrdinalIgnoreCase), true);
                     if (assignment == null)
                     {
-                        var contents = File.ReadAllText(_ps1FileName);
-                        contents = $"${methodName} = {{{Environment.NewLine}}}{Environment.NewLine}{contents}";
-                        File.WriteAllText(_ps1FileName, contents);
+                        powerShellCodeDomProvider.InsertAfterScriptPreamble(_ps1FileName, $"${methodName} = {{{Environment.NewLine}}}{Environment.NewLine}");
                     }
                 }
             }
@@ -785,7 +844,7 @@ namespace PowerShellToolsPro.FormsDesigner
 
             if (functionExists) return;
 
-            powerShellCodeDomProvider.InsertIntoBeginningOfFile(_ps1FileName, $"${functionName} = {{\r\n\r\n}}\r\n\r\n");
+            powerShellCodeDomProvider.InsertAfterScriptPreamble(_ps1FileName, $"${functionName} = {{\r\n\r\n}}\r\n\r\n");
         }
 
         private void GenerateCodeFromField(CodeMemberField e, TextWriter w, CodeGeneratorOptions o)

--- a/PowerShellTools.Shared/FormDesigner/PSCodeDomProvider.cs
+++ b/PowerShellTools.Shared/FormDesigner/PSCodeDomProvider.cs
@@ -67,10 +67,10 @@ namespace PowerShellToolsPro.FormDesigner
             return doc.GetFileName();
         }
 
-        public override void InsertIntoBeginningOfFile(string fileName, string text)
+        protected override void InsertIntoFile(string fileName, string text, int offset)
         {
             var file = _visualStudio.GetFile(fileName);
-            file.InsertAtBeginningOfDocument(text);
+            file.InsertAtDocumentOffset(text, offset);
         }
 
         [ImportingConstructor]

--- a/PowerShellTools.Shared/IVisualStudio.cs
+++ b/PowerShellTools.Shared/IVisualStudio.cs
@@ -41,6 +41,7 @@ namespace PowerShellToolsPro
         void ReplaceSelection(string text);
 	    void InsertAtCaret(string text);
         void InsertAtBeginningOfDocument(string text);
+        void InsertAtDocumentOffset(string text, int offset);
 		bool IsPowerShellScript { get; }
 	}
 }

--- a/PowerShellTools.Shared/VisualStudio.cs
+++ b/PowerShellTools.Shared/VisualStudio.cs
@@ -183,6 +183,15 @@ namespace PowerShellToolsPro
 			_projectItem.Document.Save();
 		}
 
+        public void InsertAtDocumentOffset(string text, int offset)
+        {
+            var textDoc = (TextDocument)_projectItem.Document.Object("TextDocument");
+            var editPoint = textDoc.StartPoint.CreateEditPoint();
+            editPoint.CharRight(offset);
+            editPoint.Insert(text);
+            _projectItem.Document.Save();
+        }
+
         public void ReplaceSelection(string text)
         {
             var textDoc = (TextDocument)_projectItem.Document.Object("TextDocument");


### PR DESCRIPTION
Generated Windows Forms event and function stubs were being inserted at the very top of PowerShell scripts, which could push required preamble statements like `#requires`, `using`, and top-level `param(...)` blocks out of their valid positions.

This updates the form designer CodeDOM path to calculate a script preamble insertion point and route both event variable and function stub generation through it. The VS live-document integration now inserts at that computed offset, while command-line generation uses the same shared helper.

Validation:
- `dotnet test .\FormDesigner.Test\FormDesigner.Test.csproj --no-restore --nologo`

Note: A VS project build was attempted but this environment is missing the VSSDK targets required by the project.