### PR TITLE
Update websocket-driver to patched version

### DIFF
--- a/vscode/powershellprotools/package-lock.json
+++ b/vscode/powershellprotools/package-lock.json
@@ -1416,9 +1416,9 @@
             "license": "MIT"
         },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
Dependabot flagged the VS Code extension lockfile because `json-rpc2` resolves `websocket-driver` through `faye-websocket` at vulnerable version 0.7.4.

This updates the locked transitive `websocket-driver` package to 0.7.5, preserving the existing dependency graph while resolving the advisory.

Validation: `npm audit` no longer reports a `websocket-driver` vulnerability.