### PR TITLE
Enable optional CI code signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,24 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      sign_code:
+        description: Sign build outputs
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
     name: Build repository
     timeout-minutes: 120
     runs-on: windows-latest
+    env:
+      SIGNING_CODE: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_code && secrets.SIGNING_CODE || '' }}
+      AZURE_CLIENT_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_code && secrets.AZURE_CLIENT_ID || '' }}
+      AZURE_TENANT_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_code && secrets.AZURE_TENANT_ID || '' }}
+      AZURE_CLIENT_SECRET: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_code && secrets.AZURE_CLIENT_SECRET || '' }}
 
     steps:
     - name: Checkout
@@ -77,10 +89,6 @@ jobs:
       shell: pwsh
       run: |
         .\PowerShellToolsPro.Cmdlets\build.ps1
-      env:
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
     - name: Build VS Code extension
       shell: pwsh
@@ -88,10 +96,6 @@ jobs:
         Import-Module .\Build\Modules\InvokeBuild\5.14.23\InvokeBuild.psd1 -Force
         Install-Module Microsoft.PowerShell.PlatyPS -RequiredVersion 1.0.1 -Scope CurrentUser -Force -AllowClobber
         Invoke-Build -File .\vscode\vscode.build.ps1
-      env:
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
     - name: Upload Visual Studio extensions
       uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,7 @@ jobs:
       run: |
         .\PowerShellToolsPro.Cmdlets\build.ps1
       env:
+        SIGNING_CODE: ${{ secrets.SIGNING_CODE }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -87,6 +88,7 @@ jobs:
         Install-Module Microsoft.PowerShell.PlatyPS -RequiredVersion 1.0.1 -Scope CurrentUser -Force -AllowClobber
         Invoke-Build -File .\vscode\vscode.build.ps1
       env:
+        SIGNING_CODE: ${{ secrets.SIGNING_CODE }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/Build/sign.ps1
+++ b/Build/sign.ps1
@@ -1,5 +1,11 @@
 param($Path)
 
+$signingCode = $env:SIGNING_CODE
+if ([string]::IsNullOrWhiteSpace($signingCode) -or $signingCode -eq 'false' -or $signingCode -eq '0') {
+    Write-Warning "Code signing is disabled. Skipping signing."
+    return
+}
+
 $OpenAuthenticode = Import-Module OpenAuthenticode -PassThru -ErrorAction Ignore
 if ($null -eq $OpenAuthenticode) {
     Install-Module OpenAuthenticode -Force -Scope CurrentUser -AllowClobber
@@ -8,8 +14,7 @@ if ($null -eq $OpenAuthenticode) {
 $key = Get-OpenAuthenticodeAzKey -Vault ims-hms2 -Certificate Global-Sign-Cert -ErrorAction SilentlyContinue
 
 if ($null -eq $Key) {
-    Write-Warning "No signing key available. Skipping signing."
-    return
+    throw "Code signing was requested, but no signing key is available."
 }
 
 $signParams = @{


### PR DESCRIPTION
Add a manual CI input that only exposes signing credentials for workflow_dispatch runs when requested. Gate the shared signing script on SIGNING_CODE so push and PR builds remain unsigned. Preserve publish signing by passing the signing flag through the build steps.