### PR TITLE
Update publishing workflow secret references

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,7 +99,7 @@ jobs:
         Rename-Item .\PowerShellToolsPro.Cmdlets\out PowerShellProTools
         Publish-Module -Path .\PowerShellToolsPro.Cmdlets\PowerShellProTools -NuGetApiKey $ENV:PSGALLERY
       env:
-        PSGALLERY: ${{ secrets.PSGALLERY }}
+        PSGALLERY: ${{ secrets.IMS_PSGALLERY }}
 
     - name: Publish VS Code extension
       shell: pwsh
@@ -108,7 +108,7 @@ jobs:
         $Version = (ConvertFrom-Json (Get-Content -Raw .\package.json)).Version
         vsce publish --pat $ENV:VSCE --packagePath ".\kit\powershellprotools-$($Version).vsix"
       env:
-        VSCE: ${{ secrets.VSCODE_MARKETPLACE_KEY }}
+        VSCE: ${{ secrets.IMS_VSCODE }}
 
     - name: Publish VS Code extension to Open VSX
       shell: pwsh


### PR DESCRIPTION
## Summary
- Use the renamed PowerShell Gallery secret for module publishing
- Use the renamed VS Code Marketplace secret for extension publishing

## Testing
- Not run (not requested)