### PR TITLE
Resolve relative package roots against the working directory

### DIFF
--- a/PowerShellToolsPro.Packager.Test/ConfigDeserializerTests.cs
+++ b/PowerShellToolsPro.Packager.Test/ConfigDeserializerTests.cs
@@ -1,5 +1,8 @@
 ﻿using PowerShellToolsPro.Packager.Config;
+using System;
 using System.Collections;
+using System.IO;
+using PowerShellToolsPro.Packager;
 using Xunit;
 
 namespace PowerShellToolsPro.Packager.Test
@@ -40,6 +43,17 @@ namespace PowerShellToolsPro.Packager.Test
             var config = deserializer.Deserialize(hashtable);
 
             Assert.Equal("http://timestamp.digicert.com", config.Package.TimestampServer);
+        }
+
+        [Fact]
+        public void ShouldResolveRelativeRootAgainstWorkingDirectory()
+        {
+            var process = new PackageProcess();
+            process.Config.Root = @"scripts\entry.ps1";
+
+            new RootPathStage().Execute(process, null);
+
+            Assert.Equal(Path.Combine(Environment.CurrentDirectory, @"scripts\entry.ps1"), process.Config.Root);
         }
     }
 

--- a/PowerShellToolsPro.Packager/PackageProcess.cs
+++ b/PowerShellToolsPro.Packager/PackageProcess.cs
@@ -17,6 +17,7 @@ namespace PowerShellToolsPro.Packager
             _stages = new Stage[]
             {
                 new ValidateStage(),
+                new RootPathStage(),
                 new OutputPathStage(),
                 new BundleStage(),
                 new CompileStage(),
@@ -267,6 +268,24 @@ namespace PowerShellToolsPro.Packager
             }
 
             process.Config.OutputPath = outputDirectory;
+
+            return Success(process.Script);
+        }
+    }
+
+    public class RootPathStage : Stage
+    {
+        public override bool ShouldExecute(PackageProcess process, StageResult previousStage)
+        {
+            return true;
+        }
+
+        public override StageResult Execute(PackageProcess process, StageResult previousStage)
+        {
+            if (!string.IsNullOrEmpty(process.Config.Root) && !Path.IsPathRooted(process.Config.Root))
+            {
+                process.Config.Root = Path.Combine(Environment.CurrentDirectory, process.Config.Root);
+            }
 
             return Success(process.Script);
         }


### PR DESCRIPTION
## Summary

- Resolve relative package roots against the current working directory during packaging
- Add unit coverage for relative root resolution

## Testing

- Added unit test coverage for relative packaging root resolution