### PR TITLE
Avoid redundant casts in Form Designer code generation

### DIFF
--- a/FormDesigner/CodeDom/PowerShellCodeDomProvider.cs
+++ b/FormDesigner/CodeDom/PowerShellCodeDomProvider.cs
@@ -611,10 +611,32 @@ namespace PowerShellToolsPro.FormsDesigner
 
 		private void GenerateCodeFromCodeCastExpression(CodeCastExpression e, TextWriter w, CodeGeneratorOptions o)
 	    {
+			while (e.Expression is CodeCastExpression && TypesMatch(e.TargetType, ((CodeCastExpression)e.Expression).TargetType))
+			{
+				e = (CodeCastExpression)e.Expression;
+			}
+
+			var primitive = e.Expression as CodePrimitiveExpression;
+			if (primitive != null && primitive.Value != null && TypesMatch(e.TargetType, primitive.Value.GetType()))
+			{
+				GenerateCodeFromPrimitiveExpression(primitive, w, o);
+				return;
+			}
+
 			w.Write("([" + e.TargetType.BaseType + "]");
 			GenerateCodeFromExpression(e.Expression, w, o);
 			w.Write(")");
 	    }
+
+		private static bool TypesMatch(CodeTypeReference typeReference, Type type)
+		{
+			return typeReference.BaseType.Equals(type.FullName, StringComparison.Ordinal);
+		}
+
+		private static bool TypesMatch(CodeTypeReference left, CodeTypeReference right)
+		{
+			return left.BaseType.Equals(right.BaseType, StringComparison.Ordinal);
+		}
 
         private void GenerateCodeFromCodeAttachEventStatement(CodeAttachEventStatement e, TextWriter w,
             CodeGeneratorOptions o)

--- a/PowerShellTools.Test/FormsDesigner/CodeDomAstVisitor.Test.cs
+++ b/PowerShellTools.Test/FormsDesigner/CodeDomAstVisitor.Test.cs
@@ -64,5 +64,21 @@ $resources = Invoke-Expression (Get-Content ""$PSScriptRoot\MultiThreadedForm.De
             Assert.Equal("System.ComponentModel.ComponentResourceManager", objectCreate.CreateType.BaseType);
             Assert.Equal("MainForm", (objectCreate.Parameters[0] as CodeTypeOfExpression).Type.BaseType);
         }
+
+        [Fact]
+        public void ShouldNotGenerateRedundantCasts()
+        {
+            var generator = new PowerShellCodeGenerator(null, EventGenerationType.Variable);
+            var expression = new CodeCastExpression(typeof(int),
+                new CodeCastExpression(typeof(byte),
+                    new CodeCastExpression(typeof(byte), new CodePrimitiveExpression((byte)192))));
+
+            using (var writer = new StringWriter())
+            {
+                generator.GenerateCodeFromExpression(expression, writer, null);
+
+                Assert.Equal("([System.Int32][System.Byte]192)", writer.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Collapse nested casts with matching target types.
- Skip casts when a primitive already has the target type.
- Add coverage for redundant cast generation.

## Testing
- Added a unit test verifying simplified cast output.